### PR TITLE
Use the same karma configuration properties and remove outdated scripts and dependencies

### DIFF
--- a/common/changes/@robotlegsjs/core/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/core/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/core",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/core",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/createjs/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/createjs/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/createjs",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/createjs",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/eventemitter3/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/eventemitter3/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/eventemitter3",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/eventemitter3",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/macrobot/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/macrobot/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/macrobot",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/macrobot",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/openfl/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/openfl/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/openfl",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/openfl",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/phaser-ce-signalcommandmap/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/phaser-ce-signalcommandmap/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/phaser-ce-signalcommandmap",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/phaser-ce-signalcommandmap",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/phaser-ce/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/phaser-ce/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/phaser-ce",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/phaser-ce",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/phaser/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/phaser/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/phaser",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/phaser",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/pixi-palidor/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/pixi-palidor/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/pixi-palidor",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/pixi-palidor",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/pixi-signalmediator/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/pixi-signalmediator/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/pixi-signalmediator",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/pixi-signalmediator",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/pixi/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/pixi/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/pixi",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/pixi",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/signalcommandmap/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/signalcommandmap/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/signalcommandmap",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/signalcommandmap",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/changes/@robotlegsjs/signals/upgrade-and-cleanup_2021-06-26-11-50.json
+++ b/common/changes/@robotlegsjs/signals/upgrade-and-cleanup_2021-06-26-11-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@robotlegsjs/signals",
+      "comment": "Use the same karma configuration properties and remove outdated scripts and dependencies (see [24](https://github.com/RobotlegsJS/RobotlegsJS-Framework/pull/24))",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@robotlegsjs/signals",
+  "email": "tiago.schenkel@gmail.com"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -139,10 +139,6 @@
       "allowedCategories": [ "games", "production", "tests" ]
     },
     {
-      "name": "karma-commonjs",
-      "allowedCategories": [ "production" ]
-    },
-    {
       "name": "karma-coverage-istanbul-reporter",
       "allowedCategories": [ "games", "production", "tests" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -99,10 +99,6 @@
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "glslify",
-      "allowedCategories": [ "production", "tests" ]
-    },
-    {
       "name": "gsap",
       "allowedCategories": [ "games" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -135,10 +135,6 @@
       "allowedCategories": [ "games", "production", "tests" ]
     },
     {
-      "name": "karma-chai-sinon",
-      "allowedCategories": [ "production", "tests" ]
-    },
-    {
       "name": "karma-chrome-launcher",
       "allowedCategories": [ "games", "production", "tests" ]
     },
@@ -228,7 +224,7 @@
     },
     {
       "name": "sinon-chai",
-      "allowedCategories": [ "production", "tests" ]
+      "allowedCategories": [ "games", "production", "tests" ]
     },
     {
       "name": "source-map-support",

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -203,10 +203,6 @@
       "allowedCategories": [ "games", "production", "tests" ]
     },
     {
-      "name": "remap-istanbul",
-      "allowedCategories": [ "production" ]
-    },
-    {
       "name": "rimraf",
       "allowedCategories": [ "games", "production", "tests" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -111,10 +111,6 @@
       "allowedCategories": [ "games", "production" ]
     },
     {
-      "name": "imports-loader",
-      "allowedCategories": [ "games", "production", "tests" ]
-    },
-    {
       "name": "inversify",
       "allowedCategories": [ "production" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -147,10 +147,6 @@
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "karma-coverage",
-      "allowedCategories": [ "production" ]
-    },
-    {
       "name": "karma-coverage-istanbul-reporter",
       "allowedCategories": [ "games", "production", "tests" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -43,10 +43,6 @@
       "allowedCategories": [ "games", "production", "tests" ]
     },
     {
-      "name": "browserify-versionify",
-      "allowedCategories": [ "production", "tests" ]
-    },
-    {
       "name": "chai",
       "allowedCategories": [ "games", "production", "tests" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -143,10 +143,6 @@
       "allowedCategories": [ "games", "production", "tests" ]
     },
     {
-      "name": "karma-es6-shim",
-      "allowedCategories": [ "games", "production", "tests" ]
-    },
-    {
       "name": "karma-mocha",
       "allowedCategories": [ "games", "production", "tests" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -34,7 +34,6 @@ specifiers:
   '@types/tweenjs': ^1.0.3
   '@types/webpack-env': ^1.16.0
   bluebird: ^3.7.2
-  browserify-versionify: ^1.0.6
   chai: ^4.3.4
   clean-webpack-plugin: ^3.0.0
   copy-webpack-plugin: ^9.0.1
@@ -117,7 +116,6 @@ dependencies:
   '@types/tweenjs': 1.0.3
   '@types/webpack-env': 1.16.0
   bluebird: 3.7.2
-  browserify-versionify: 1.0.6
   chai: 4.3.4
   clean-webpack-plugin: 3.0.0_webpack@5.40.0
   copy-webpack-plugin: 9.0.1_webpack@5.40.0
@@ -1873,13 +1871,6 @@ packages:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
     dev: false
 
-  /browserify-versionify/1.0.6:
-    resolution: {integrity: sha1-qy3GHWoRnmJ77Eh1mNGYO3/bJ14=}
-    dependencies:
-      find-root: 0.1.2
-      through2: 0.6.3
-    dev: false
-
   /browserslist/4.16.6:
     resolution: {integrity: sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -3535,10 +3526,6 @@ packages:
       commondir: 1.0.1
       make-dir: 3.1.0
       pkg-dir: 4.2.0
-    dev: false
-
-  /find-root/0.1.2:
-    resolution: {integrity: sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE=}
     dev: false
 
   /find-up/2.1.0:
@@ -6211,15 +6198,6 @@ packages:
       type-fest: 0.6.0
     dev: false
 
-  /readable-stream/1.0.34:
-    resolution: {integrity: sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=}
-    dependencies:
-      core-util-is: 1.0.2
-      inherits: 2.0.4
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: false
-
   /readable-stream/2.3.7:
     resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
     dependencies:
@@ -6995,10 +6973,6 @@ packages:
       define-properties: 1.1.3
     dev: false
 
-  /string_decoder/0.10.31:
-    resolution: {integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=}
-    dev: false
-
   /string_decoder/1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
@@ -7188,13 +7162,6 @@ packages:
 
   /through/2.3.8:
     resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
-    dev: false
-
-  /through2/0.6.3:
-    resolution: {integrity: sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=}
-    dependencies:
-      readable-stream: 1.0.34
-      xtend: 4.0.2
     dev: false
 
   /thunky/1.1.0:
@@ -7905,11 +7872,6 @@ packages:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: false
 
-  /xtend/4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-    dev: false
-
   /y18n/4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
     dev: false
@@ -8021,7 +7983,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-OmiXCZ9NHmHWDvpzJsY7H2okTAwjGJ+9xo/3BhwIF9ibZsbQK1k34QhBvX4XCXmVd9/QPimTCw8J9Qq2bMBuIg==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-jBj4/4umG2zqhan+uSZXQG3hL1QxZnODErjiU2Vv7j8hDCcDapGVTmOmCFylk+y6J4Vs1T+n1HLXkUxoWq+TLA==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8033,7 +7995,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -8088,7 +8049,7 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-n+PUh1YOKYistJ7gaGyKXajhlLjDx082GXUzolF+IGfPIfJSlKTfVFTDZubPprCE1lpBZsVvQG6be9Ym+dLEJA==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-aY0R6aNXnmMDiPWspbR3HZcZVpYCwY0o5SPUGquSbSn3l/0FF+b4dYDOiCN+16nlYSAJPHFlw3itM1yIVwQp2g==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
@@ -8103,7 +8064,6 @@ packages:
       '@types/tweenjs': 1.0.3
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
       copy-webpack-plugin: 9.0.1_webpack@5.40.0
@@ -8157,7 +8117,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-OjItDQCOsTGsKw3Hk2ta/i/0faq/c/IXfcKkj/+1VyJhZ81vZUS/freOYbaTNCKfDSqWsJdbMA0CItoMTWi42A==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-MQIlAbPDp68IX8vGW3oaYxhv5Q+wvLY74o7GhoJFUdPdGqxQ3L3afG/P6higW6nD6OadewNGR/jQx+GiVjc4yg==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8169,7 +8129,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -8523,7 +8482,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-L0qCEVu3MXNQ+joMqhgFSULBWqA4sCoATaeJVtoMXHa9+DCNA2Z/1cbq7PGV9OmvathPXhuAPl6yIkXdFEv1+A==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-jzDb+m6clETpatYpzhl6I0MVLjJatpHOkVSDgB/hx79PY369mjK9u+KTQJRGhrcQegLvUVSEw/w8BL8T1y6TMg==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8535,7 +8494,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -8586,7 +8544,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-VsRb2q5fLK32A5kMAwk+uyjOJfuh/gpUGto8Rep4cjX+jYGJr/LKYb9yDcSNWwf912Fzn2ePuJsBHJ9pQvPcJQ==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-e6QjuWDkImWBhRAudsyWgewPGPNSbdcT7n9sa8CRlAWbTFblKFPPgEK4aVNxQgdUEcoPklZEWWsD8Bed0g/jIA==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -8598,7 +8556,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -8649,7 +8606,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-6l2JjGKZMvZ0ETVPWUq9EMY0zEEKZuXtJgxKuRuipVZJHK8u4qwb7KbKBZMsY5Ajy/gjb7NusIZcpGmwj4R+jw==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-XR/NPZo14aaR75pWmN7Uby+gDA0MVlyYjk0asuQVNtVnrUGsBQLqKgSlqp9zX0nw3+5APW6cUrCQgnetDbdUNw==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -8661,7 +8618,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
       copy-webpack-plugin: 9.0.1_webpack@5.40.0
@@ -8714,7 +8670,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-KwriZYzsomAvVGQisun0peft0wH3+b8KsRUIi9+ii9z/ktItJXefWP91Dcd9tj2UuXaJN63UZiErsBqBsP087w==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-rVucOipnidj8fuqehOtYaXexf1dvmTizL/ts6IJ/5dwZ3zb2kf+tP3p3rMZ8hBzGXB298phOliAmMMs3QtcmxA==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8725,7 +8681,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -8775,7 +8730,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-BgAIFaNP/I21ugrJMuRI4eSRF/QyCAjGgnfdXNLlkLeuIFRMWCmG4RR4PWC+JQX3HMtmikCQbkUhDUwNTBRy7w==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-XOju3+K2hWxVPxf+c9slyBEELhf2QZwwQQP0bKLgBRTgeLKWrD99PXMNQRcKr1hdmELZzOkgcTSk73lEXe4nNw==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
@@ -8787,7 +8742,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
       es6-map: 0.1.5
@@ -8840,7 +8794,7 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-ibpIw8ZmPcuoWOZJH9e+ee+GM1FWNlMgetR+Y1q9oPRN3HJwrTNl0zK4TZag6ykCBaQP5iUZGMhjNLjozVaxEA==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-9rGu24ufbpW6p4/FFg7cQvvtgYOgmsZFkxJh1BOOQZtbgqQ5EvbWgFeZjSRpgjM+n943EOUSzVKwmih2KJN5Gg==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
@@ -8852,7 +8806,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
       copy-webpack-plugin: 9.0.1_webpack@5.40.0
@@ -8906,7 +8859,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-e3d2/tsFqxxjN8alPB0yTDis+sU4ru79FNrf44gowKgWHUmjK6eSlKorJ5FtI9UuQmf4EI/9/5khY1vnlAFYNA==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-Cg4ct3H1c1D5V4UisqhxGK/IhltDM4WdTNsXcEVuYm4ZSsR7FbpPjYflvsqR8XIZCbLADiJhW3Z14CM4pqBMdA==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -8917,7 +8870,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
       copy-webpack-plugin: 9.0.1_webpack@5.40.0
@@ -8970,7 +8922,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-5ErglEmmpeTLv3RJhZaOsD8Md9g7m8AS4oifMUpm1nzBhvqZyD3T5VsTkZ7PGmEOtpD+QQOqpQXsRf7MPXaCCA==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-gjyj3punm88bbf92xJ/olrUXfcedQySeWqeW1m5fvopPI4ojzWtbFnqaFkN/A2mt5tI4hG0teUOrWeIYOc63cQ==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -8982,7 +8934,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -9034,7 +8985,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-FpN9KV4CRH8f63GK+Fqo3atIBy23WX56co39fKCP03HfzkYZX/IwHCnPmJOGvaTBec7GtKZ0KMJRXhhd4Ab/sQ==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-/pJnZH89faSFJPOma7CstCB68eBAyAFVGfxgdbuWauSIpMGYefvpbkeUruha50d7+Cn38D6rcY5v3zk8dp8YFg==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9045,7 +8996,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
       copy-webpack-plugin: 9.0.1_webpack@5.40.0
@@ -9098,7 +9048,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-+I0bXpY6wSHorJW3W+4MMQFasEMeNWFBmDeELzUsUXEnADjDE/tedNSBNen2u0ZznL12oZL6Z17KCjozppkuLw==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-BRpbQxhmw8goIROAHv5DQVaofIfYD3qhjRo3Yh+VDe2jg4n+aRE3Z0CxCtv+htes9UbacNuWCrMY9q5kW+OaXg==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9110,7 +9060,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -9161,7 +9110,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-FhiVDtFlBZngHQFZdHR2HczcKqcFqccQUS/qblkBIhtb0ZpGOSl9j02AEIMd09i92K0N5dcZLAN1mUuw19xEvA==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-y4O05musOI0jln5xw/mZbLTkAZiSNuaDF7/x/QhSFhK/iXksHfTzNx3Ju9K8k9eM9ehcDQnPKuOk+EOfXFR6tA==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:
@@ -9173,7 +9122,6 @@ packages:
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0
       bluebird: 3.7.2
-      browserify-versionify: 1.0.6
       chai: 4.3.4
       es6-map: 0.1.5
       es6-symbol: 3.1.3

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -86,13 +86,13 @@ specifiers:
   ts-node: ^10.0.0
   tslib: ^2.2.0
   typescript: ~4.2.4
-  webpack: ^5.39.1
+  webpack: ^5.40.0
   webpack-cli: ^4.7.2
   webpack-dev-server: ^3.11.2
 
 dependencies:
   '@istanbuljs/nyc-config-typescript': 1.0.1_40f74ebf3b42f8d97356b2262606f547
-  '@mcler/webpack-concat-plugin': 4.1.3_2f72f18684a1c9b9d7779307cad6faa4
+  '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
   '@rush-temp/core': file:projects/core.tgz
   '@rush-temp/createjs': file:projects/createjs.tgz
   '@rush-temp/eventemitter3': file:projects/eventemitter3.tgz
@@ -126,8 +126,8 @@ dependencies:
   bluebird: 3.7.2
   browserify-versionify: 1.0.6
   chai: 4.3.4
-  clean-webpack-plugin: 3.0.0_webpack@5.39.1
-  copy-webpack-plugin: 9.0.0_webpack@5.39.1
+  clean-webpack-plugin: 3.0.0_webpack@5.40.0
+  copy-webpack-plugin: 9.0.0_webpack@5.40.0
   easeljs: 1.0.2
   es6-map: 0.1.5
   es6-symbol: 3.1.3
@@ -139,10 +139,10 @@ dependencies:
   eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
   glslify: 7.1.1
   gsap: 1.20.6
-  html-webpack-plugin: 5.3.1_webpack@5.39.1
-  imports-loader: 3.0.0_webpack@5.39.1
+  html-webpack-plugin: 5.3.1_webpack@5.40.0
+  imports-loader: 3.0.0_webpack@5.40.0
   inversify: 5.1.1
-  istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+  istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
   jsdom: 16.6.0
   jsdom-global: 3.0.2_jsdom@16.6.0
   karma: 6.3.4
@@ -157,7 +157,7 @@ dependencies:
   karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
   karma-sourcemap-loader: 0.3.8
   karma-sourcemap-writer: 0.1.2
-  karma-webpack: 5.0.0_webpack@5.39.1
+  karma-webpack: 5.0.0_webpack@5.40.0
   mocha: 9.0.1
   nyc: 15.1.0
   phaser: 3.22.0
@@ -171,14 +171,14 @@ dependencies:
   sinon: 11.1.1
   sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
   source-map-support: 0.5.19
-  terser-webpack-plugin: 5.1.3_webpack@5.39.1
-  ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+  terser-webpack-plugin: 5.1.3_webpack@5.40.0
+  ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
   ts-node: 10.0.0_typescript@4.2.4
   tslib: 2.2.0
   typescript: 4.2.4
-  webpack: 5.39.1_webpack-cli@4.7.2
-  webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-  webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+  webpack: 5.40.0_webpack-cli@4.7.2
+  webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+  webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
 
 packages:
 
@@ -483,7 +483,7 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /@mcler/webpack-concat-plugin/4.1.3_2f72f18684a1c9b9d7779307cad6faa4:
+  /@mcler/webpack-concat-plugin/4.1.3_526cece0d5c3279c7eb6f6ca6be02a57:
     resolution: {integrity: sha512-usy0VPy7afO58etf4Ln7RXH09USOfd6H5DaXiXqvDOuFuCIacpLcuBDJpjxgEatA8F12ht886Yd5xZwKki/dkQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -492,10 +492,10 @@ packages:
       webpack-sources: ^2.2.0
     dependencies:
       globby: 8.0.2
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
       schema-utils: 3.0.0
       upath: 2.0.1
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /@microsoft/tsdoc-config/0.15.2:
@@ -1328,14 +1328,14 @@ packages:
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webpack-cli/configtest/1.0.4_webpack-cli@4.7.2+webpack@5.39.1:
+  /@webpack-cli/configtest/1.0.4_webpack-cli@4.7.2+webpack@5.40.0:
     resolution: {integrity: sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
     dev: false
 
   /@webpack-cli/info/1.3.0_webpack-cli@4.7.2:
@@ -1344,7 +1344,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
     dev: false
 
   /@webpack-cli/serve/1.5.1_8f539f003d3f73da23f531c906cfc201:
@@ -1356,8 +1356,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     dev: false
 
   /@xtuc/ieee754/1.2.0:
@@ -2162,7 +2162,7 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /clean-webpack-plugin/3.0.0_webpack@5.39.1:
+  /clean-webpack-plugin/3.0.0_webpack@5.40.0:
     resolution: {integrity: sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==}
     engines: {node: '>=8.9.0'}
     peerDependencies:
@@ -2170,7 +2170,7 @@ packages:
     dependencies:
       '@types/webpack': 4.41.29
       del: 4.1.1
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /cliui/5.0.0:
@@ -2369,7 +2369,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /copy-webpack-plugin/9.0.0_webpack@5.39.1:
+  /copy-webpack-plugin/9.0.0_webpack@5.40.0:
     resolution: {integrity: sha512-k8UB2jLIb1Jip2nZbCz83T/XfhfjX6mB1yLJNYKrpYi7FQimfOoFv/0//iT6HV1K8FwUB5yUbCcnpLebJXJTug==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -2382,7 +2382,7 @@ packages:
       p-limit: 3.1.0
       schema-utils: 3.0.0
       serialize-javascript: 5.0.1
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /core-js/2.6.12:
@@ -2917,8 +2917,8 @@ packages:
       unbox-primitive: 1.0.1
     dev: false
 
-  /es-module-lexer/0.4.1:
-    resolution: {integrity: sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==}
+  /es-module-lexer/0.6.0:
+    resolution: {integrity: sha512-f8kcHX1ArhllUtb/wVSyvygoKCznIjnxhLxy7TCvIiMdT7fL4ZDTIKaadMe6eLvOXg6Wk02UeoFgUoZ2EKZZUA==}
     dev: false
 
   /es-to-primitive/1.2.1:
@@ -4251,7 +4251,7 @@ packages:
       terser: 4.8.0
     dev: false
 
-  /html-webpack-plugin/5.3.1_webpack@5.39.1:
+  /html-webpack-plugin/5.3.1_webpack@5.40.0:
     resolution: {integrity: sha512-rZsVvPXUYFyME0cuGkyOHfx9hmkFa4pWfxY/mdY38PsBEaVNsRoA+Id+8z6DBDgyv3zaw6XQszdF8HLwfQvcdQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -4262,7 +4262,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 2.1.2
       tapable: 2.2.0
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /htmlparser2/6.1.0:
@@ -4438,7 +4438,7 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /imports-loader/3.0.0_webpack@5.39.1:
+  /imports-loader/3.0.0_webpack@5.40.0:
     resolution: {integrity: sha512-PhDB+rxpc95/1cM8ehxWAcuDIDi3eXhqHhax09iyUeAYBJ2bT6QbBp7aDj8IfU9Ns+2l1K226GhoWVAU823CTA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -4446,7 +4446,7 @@ packages:
     dependencies:
       source-map: 0.6.1
       strip-comments: 2.0.1
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /imurmurhash/0.1.4:
@@ -4823,7 +4823,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /istanbul-instrumenter-loader/3.0.1_webpack@5.39.1:
+  /istanbul-instrumenter-loader/3.0.1_webpack@5.40.0:
     resolution: {integrity: sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==}
     engines: {node: '>= 4.8 < 5.0.0 || >= 5.10'}
     peerDependencies:
@@ -4833,7 +4833,7 @@ packages:
       istanbul-lib-instrument: 1.10.2
       loader-utils: 1.4.0
       schema-utils: 0.3.0
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /istanbul-lib-coverage/1.2.1:
@@ -5237,7 +5237,7 @@ packages:
       graceful-fs: 4.2.6
     dev: false
 
-  /karma-webpack/5.0.0_webpack@5.39.1:
+  /karma-webpack/5.0.0_webpack@5.40.0:
     resolution: {integrity: sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -5245,7 +5245,7 @@ packages:
     dependencies:
       glob: 7.1.7
       minimatch: 3.0.4
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
       webpack-merge: 4.2.2
     dev: false
 
@@ -7568,7 +7568,7 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
-  /terser-webpack-plugin/5.1.3_webpack@5.39.1:
+  /terser-webpack-plugin/5.1.3_webpack@5.40.0:
     resolution: {integrity: sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -7580,7 +7580,7 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.7.0
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /terser/4.8.0:
@@ -7727,7 +7727,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /ts-loader/9.2.3_typescript@4.2.4+webpack@5.39.1:
+  /ts-loader/9.2.3_typescript@4.2.4+webpack@5.40.0:
     resolution: {integrity: sha512-sEyWiU3JMHBL55CIeC4iqJQadI0U70A5af0kvgbNLHVNz2ACztQg0j/9x10bjjIht8WfFYLKfn4L6tkZ+pu+8Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -7739,7 +7739,7 @@ packages:
       micromatch: 4.0.4
       semver: 7.3.5
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
   /ts-node/10.0.0_typescript@4.2.4:
@@ -8041,7 +8041,7 @@ packages:
     engines: {node: '>=10.4'}
     dev: false
 
-  /webpack-cli/4.7.2_7cf21cf02077ec4d39b618ad6a14b03e:
+  /webpack-cli/4.7.2_9ea8c6fb2d6dba249f7224b7196a0699:
     resolution: {integrity: sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -8062,7 +8062,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.3
-      '@webpack-cli/configtest': 1.0.4_webpack-cli@4.7.2+webpack@5.39.1
+      '@webpack-cli/configtest': 1.0.4_webpack-cli@4.7.2+webpack@5.40.0
       '@webpack-cli/info': 1.3.0_webpack-cli@4.7.2
       '@webpack-cli/serve': 1.5.1_8f539f003d3f73da23f531c906cfc201
       colorette: 1.2.2
@@ -8073,12 +8073,12 @@ packages:
       interpret: 2.2.0
       rechoir: 0.7.0
       v8-compile-cache: 2.3.0
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
       webpack-merge: 5.8.0
     dev: false
 
-  /webpack-dev-middleware/3.7.3_webpack@5.39.1:
+  /webpack-dev-middleware/3.7.3_webpack@5.40.0:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -8088,11 +8088,11 @@ packages:
       mime: 2.5.2
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 5.39.1_webpack-cli@4.7.2
+      webpack: 5.40.0_webpack-cli@4.7.2
       webpack-log: 2.0.0
     dev: false
 
-  /webpack-dev-server/3.11.2_webpack-cli@4.7.2+webpack@5.39.1:
+  /webpack-dev-server/3.11.2_webpack-cli@4.7.2+webpack@5.40.0:
     resolution: {integrity: sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==}
     engines: {node: '>= 6.11.5'}
     hasBin: true
@@ -8132,9 +8132,9 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 6.1.0
       url: 0.11.0
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-middleware: 3.7.3_webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-middleware: 3.7.3_webpack@5.40.0
       webpack-log: 2.0.0
       ws: 6.2.2
       yargs: 13.3.2
@@ -8170,8 +8170,8 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /webpack/5.39.1_webpack-cli@4.7.2:
-    resolution: {integrity: sha512-ulOvoNCh2PvTUa+zbpRuEb1VPeQnhxpnHleMPVVCq3QqnaFogjsLyps+o42OviQFoaGtTQYrUqDXu1QNkvUPzw==}
+  /webpack/5.40.0_webpack-cli@4.7.2:
+    resolution: {integrity: sha512-c7f5e/WWrxXWUzQqTBg54vBs5RgcAgpvKE4F4VegVgfo4x660ZxYUF2/hpMkZUnLjgytVTitjeXaN4IPlXCGIw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -8189,7 +8189,7 @@ packages:
       browserslist: 4.16.6
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.8.2
-      es-module-lexer: 0.4.1
+      es-module-lexer: 0.6.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -8200,9 +8200,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.0.0
       tapable: 2.2.0
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
       watchpack: 2.2.0
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
       webpack-sources: 2.3.0
     dev: false
 
@@ -8479,7 +8479,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-DzxN2g2UsgnL8eAGFknEMec4eUUW51O/FFpkBIIpy+S6lSLi3LN+wUKo4VPHkWi/eocsZranyolOwUvskqLGfw==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-ZRuGmyFCU2fYomhILk/PwjVPd5+PNrf4ZVYyu7byAeiN+EaIEvrPwOV0NvkcpIP29RMmdu8EBpgAlTN13J0fww==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8502,9 +8502,9 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
       inversify: 5.1.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       jsdom: 16.6.0
       jsdom-global: 3.0.2_jsdom@16.6.0
       karma: 6.3.4
@@ -8517,7 +8517,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       prettier: 2.3.1
@@ -8527,14 +8527,14 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8550,11 +8550,11 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-6mif+VYSyfCTuVHiIXC5xNJWXfnHC5IWZUwl1yYJ7qg6xYabBujY82vhMU2J8DZADpu1Y7B2p727DHkjAWnh/w==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-Nd64dhtGrFVISFwUtfLhr2w5lyZR4P0omD4GrKTptJwkF7lSZEAc9DhtGQGDPHTm/CaE3uPeWFMSNOYMAwzIhw==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
-      '@mcler/webpack-concat-plugin': 4.1.3_2f72f18684a1c9b9d7779307cad6faa4
+      '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
@@ -8567,8 +8567,8 @@ packages:
       bluebird: 3.7.2
       browserify-versionify: 1.0.6
       chai: 4.3.4
-      clean-webpack-plugin: 3.0.0_webpack@5.39.1
-      copy-webpack-plugin: 9.0.0_webpack@5.39.1
+      clean-webpack-plugin: 3.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.0_webpack@5.40.0
       easeljs: 1.0.2
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -8579,9 +8579,9 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -8591,7 +8591,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       prettier: 2.3.1
       puppeteer: 10.0.0
@@ -8600,14 +8600,14 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8623,7 +8623,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-XC1uIoFhDNszFeVG1OpEp4XZX2w6Wxe1G1NFh1wXdYpwO5UML1fQsFtUJ+JKzCjuyBGOQQe0xnnwhmdXxq4lLg==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-G/jvdzcDR9JLA60YKU641Qml7mnQFJN1O9BgvJB9Uh7dPfoWACWxZgmqjFCF9Ypa6u5Iv7WCiCd9UVVA4xQ+Ww==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8647,8 +8647,8 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       eventemitter3: 4.0.7
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       jsdom: 16.6.0
       jsdom-global: 3.0.2_jsdom@16.6.0
       karma: 6.3.4
@@ -8660,7 +8660,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       prettier: 2.3.1
@@ -8670,14 +8670,14 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8693,7 +8693,7 @@ packages:
     dev: false
 
   file:projects/game-battleship.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-VFNYU7QP053edFLkbDHHPB3qNxc0G/p/sfqabhlLiFmkoKWMUlw06L8Wui3LpvAuxfSAu/+WZMVrikTh4ahL0Q==, tarball: file:projects/game-battleship.tgz}
+    resolution: {integrity: sha512-AOhvnPNyh8vTQfxswnXNKww9i14aXCNObMXBmPY0gZkU2V1QZKWlEnXiAH7ZGBwBk2e5v6ge3DRh5Oi0jycytw==, tarball: file:projects/game-battleship.tgz}
     id: file:projects/game-battleship.tgz
     name: '@rush-temp/game-battleship'
     version: 0.0.0
@@ -8715,8 +8715,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       gsap: 1.20.6
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -8726,7 +8726,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       pixi.js: 5.2.1
       prettier: 2.3.1
@@ -8734,14 +8734,14 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8757,7 +8757,7 @@ packages:
     dev: false
 
   file:projects/game-match3.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-R9u/x6pWsXDGcIsW/m9UDM7fTOzmq9vwP9g8FQZ/AbHyjsokf95CKVmsfSaunrEK+y874Ycs0M+NHIEqu64YQA==, tarball: file:projects/game-match3.tgz}
+    resolution: {integrity: sha512-Wv0wJZuTf7XBsqaZfZ8BHEyCy9hNnOaMR+xS9iaJUXN9+tYz6t/5PaG+tIPTfFJ4MYmOGHIQpqrBEFIFg+Nvxg==, tarball: file:projects/game-match3.tgz}
     id: file:projects/game-match3.tgz
     name: '@rush-temp/game-match3'
     version: 0.0.0
@@ -8779,8 +8779,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       gsap: 1.20.6
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -8790,7 +8790,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       pixi.js: 5.2.1
       prettier: 2.3.1
@@ -8798,14 +8798,14 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8821,7 +8821,7 @@ packages:
     dev: false
 
   file:projects/game-minesweeper.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-jlBvM+1aGimdpqxbY+Sxm2as0A73P4Jesa/qQOeNIpVwINYBfFbJk9O0InppU9bGTyjnpDhhSkMKZgEWCJVffw==, tarball: file:projects/game-minesweeper.tgz}
+    resolution: {integrity: sha512-SsPFnLzTgJ8hXRjc+aBFDFepukmGwmdJf1XDOrvWwn+zdfyfLq02tDNjWHALJKrLXQMSIwDW9lBTtYVx04fbEQ==, tarball: file:projects/game-minesweeper.tgz}
     id: file:projects/game-minesweeper.tgz
     name: '@rush-temp/game-minesweeper'
     version: 0.0.0
@@ -8843,8 +8843,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       gsap: 1.20.6
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -8854,7 +8854,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       pixi.js: 5.2.1
       prettier: 2.3.1
@@ -8862,14 +8862,14 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8885,7 +8885,7 @@ packages:
     dev: false
 
   file:projects/game-scratchcard.tgz:
-    resolution: {integrity: sha512-plAB6Hd1lTwjofkc4U+fDnYCqoUSzpliJgGqpJmaojZ2yU2LaayLFOJ8ko3QWcTLDK+nwtKh9ZuZBzaB3p71Bw==, tarball: file:projects/game-scratchcard.tgz}
+    resolution: {integrity: sha512-D8DNBWDwM52biI7Mjnh0/PcMlSR1tWvkimj/LLLofDGpj5lPlfBm0FAPUl8EdSMiL3vjVu5SDj9Uxzdzg1KklQ==, tarball: file:projects/game-scratchcard.tgz}
     name: '@rush-temp/game-scratchcard'
     version: 0.0.0
     dependencies:
@@ -8896,20 +8896,20 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
       pixi.js: 5.2.1
       prettier: 2.3.1
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8921,7 +8921,7 @@ packages:
     dev: false
 
   file:projects/game-spaceinvaders.tgz:
-    resolution: {integrity: sha512-fNXY7n/rqWipv5ET/gr54kjkOnM/BvbjtAPrUFKnR9+/TSiZtrNSvCrPhh5lvnis8IjQDDMdKdxO2h5ekkIcfw==, tarball: file:projects/game-spaceinvaders.tgz}
+    resolution: {integrity: sha512-RokAzspCPJ12cC8y00VKEIh81av+YdQ6yR076OmytvkhfzHA4JSfo351VSEd1k+8n6l1zeRA8oUe5mOfmr6P0Q==, tarball: file:projects/game-spaceinvaders.tgz}
     name: '@rush-temp/game-spaceinvaders'
     version: 0.0.0
     dependencies:
@@ -8932,20 +8932,20 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
       pixi.js: 5.2.1
       prettier: 2.3.1
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8957,7 +8957,7 @@ packages:
     dev: false
 
   file:projects/game-tetris.tgz:
-    resolution: {integrity: sha512-B9MbW8gW9fbG5+fY6TCvgBDg/7J2sWL7juCy2UzWseWZyJjC4gSglAEb6cteJuk4u41r6I4f0aN/cljDusPWuQ==, tarball: file:projects/game-tetris.tgz}
+    resolution: {integrity: sha512-eSYGabMSTXNlrzqXstEFovsZ6OobttlnRnd8eAABlV8FJVI0m0cql319F7cjPQoWlu057NfbMswwxR2V3kwA/A==, tarball: file:projects/game-tetris.tgz}
     name: '@rush-temp/game-tetris'
     version: 0.0.0
     dependencies:
@@ -8973,7 +8973,7 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       pixi.js: 5.2.1
@@ -8981,14 +8981,14 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9000,7 +9000,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-SREvQ5g1OiMP4bKPD9GzVEHMWzzRsCKNXdNDowe9U93sQLQV04PFmFhIuaBo20RnMvEe5vlCq+7QZX49W7ls6Q==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-DlI4PTDqCNwIzC1ggvY9uZfynZaNxsWPgNg5hGCEmec4b1agso89BA0rrzyPSRwkYAg9CVMkxzQWCJnoZzLZhQ==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9023,8 +9023,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
       karma-chrome-launcher: 3.1.0
@@ -9035,7 +9035,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       prettier: 2.3.1
@@ -9045,14 +9045,14 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9067,7 +9067,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-jDeQBMtT1vgA3wRscxjEvZn9DrjySLXIWimphDk9KJN3nqxVaFWZT2LTbmZ7Lb2uKxJKGCs7cYg3ynlVBLosLA==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-TiKdBToEcI1gJauyYcuImLliWOytfFbSIZT023Bj9ofeFRIGMN8YLWyzsvAPNqptJ9K21og+thxgn+IgYo9W9g==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -9090,8 +9090,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
       karma-chrome-launcher: 3.1.0
@@ -9102,7 +9102,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       prettier: 2.3.1
@@ -9112,14 +9112,14 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9134,7 +9134,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-c8KwCA3bG8+DPv1evBsZ296obAvtsv3hevht7fINnHF8wan7kWSPmDbwrjNuTxpDvBJDtHZH4LtAAFtFBkr4Mg==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-jv4OWFwFOxJqY/9T6gapCP+2cL6bzoC3Ri05z/3a4QWzRbGfdJIuyA/FkzGXyRJ5HG80DTCs+08VXTCRvuzn+w==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -9148,8 +9148,8 @@ packages:
       bluebird: 3.7.2
       browserify-versionify: 1.0.6
       chai: 4.3.4
-      clean-webpack-plugin: 3.0.0_webpack@5.39.1
-      copy-webpack-plugin: 9.0.0_webpack@5.39.1
+      clean-webpack-plugin: 3.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.0_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9159,9 +9159,9 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -9171,7 +9171,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       openfl: 8.9.6
       prettier: 2.3.1
@@ -9180,14 +9180,14 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9202,7 +9202,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-7k0mu7StU+ziB9SKtbzbmE0g7uTcoXiPFVUnpe8Rj78A7PlG6n95dPEArcGdtro7KclSPhy0GMr02ADwbkM18Q==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-nC8vWksEtNqnxzBBgFgOjee51+SKAsAOpIxmfB2k+68f+iGWV72NFIJbokiCyPdxn7u0KIHkiugLR9XhO2O3hw==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9224,8 +9224,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -9235,7 +9235,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       phaser-ce: 2.15.0
       prettier: 2.3.1
@@ -9244,14 +9244,14 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9266,11 +9266,11 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-ozDsVL53lnxZ/Hy2hXCTtAn5HnCpER68rY1VDodJWl+jvOyUe/LNjy0YcYCXc+XIXEWOAgTsofnXB5XaS6F66g==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-2ZZcJjVa4u8XES+iLTdvXRecnoYLWCxfGPu8lDEaWvI0SBjKVLjO0Plwhed8Mh/Sdk2auSd64bvUy9+nAaHaVw==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
-      '@mcler/webpack-concat-plugin': 4.1.3_2f72f18684a1c9b9d7779307cad6faa4
+      '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
@@ -9280,7 +9280,7 @@ packages:
       bluebird: 3.7.2
       browserify-versionify: 1.0.6
       chai: 4.3.4
-      clean-webpack-plugin: 3.0.0_webpack@5.39.1
+      clean-webpack-plugin: 3.0.0_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9290,9 +9290,9 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -9302,7 +9302,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       phaser-ce: 2.15.0
       prettier: 2.3.1
@@ -9311,14 +9311,14 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9334,11 +9334,11 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-qgqUxNJcm6WRSLuNHqG+knPFj3Tf35QyRPUBU36RuPqFYzuQ2FOrvXOGiRkirOnjqdIqj31KHrNNYip0v1mOFQ==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-UV/ekt1O3Of3qPvq9S46bABYj/RCjWNCmxD+g9F/qDMWPUj8oWP2ePkkvKTHF8YAGMk+ZwwEI326LjtEVS4qqQ==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
-      '@mcler/webpack-concat-plugin': 4.1.3_2f72f18684a1c9b9d7779307cad6faa4
+      '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
@@ -9348,8 +9348,8 @@ packages:
       bluebird: 3.7.2
       browserify-versionify: 1.0.6
       chai: 4.3.4
-      clean-webpack-plugin: 3.0.0_webpack@5.39.1
-      copy-webpack-plugin: 9.0.0_webpack@5.39.1
+      clean-webpack-plugin: 3.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.0_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9359,9 +9359,9 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -9371,7 +9371,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       phaser: 3.22.0
       prettier: 2.3.1
@@ -9380,14 +9380,14 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9403,7 +9403,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-Y1VVqn4JMUENSlF4eg0/3+IR3Nh5fi3Ip8kGnb2DTphZjuox0IxYL7DPlDLNSWJdMKOBB0BxzAtsTVcF7Md+bQ==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-ovZCW2lv4Y8EiaobZeFzD/gB8Dd0WRKmfuhHI/LTApYP7y8T0aAoPwVB2OKZbN+61O7lCtpziAIRkQWH9XH+XQ==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -9416,8 +9416,8 @@ packages:
       bluebird: 3.7.2
       browserify-versionify: 1.0.6
       chai: 4.3.4
-      clean-webpack-plugin: 3.0.0_webpack@5.39.1
-      copy-webpack-plugin: 9.0.0_webpack@5.39.1
+      clean-webpack-plugin: 3.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.0_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9427,9 +9427,9 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -9439,7 +9439,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       pixi.js: 5.2.1
       prettier: 2.3.1
@@ -9449,14 +9449,14 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9471,7 +9471,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-buKVtHKpgwgYma+/XWWyyM7joCsTg58Qmqis/U0wJl0pGTQaI4+fbFkZ3vlvwttC+VxpPeggABveUhVquJsihQ==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-zUvUOQjHrnU5wrRu6baMGmEbFOWm11sTUswmUKlyCOZiXsAHPmQK09/Oo1PzYWhqGQd4AlsndGZNoBdVT/QrKA==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -9494,8 +9494,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -9506,7 +9506,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       pixi.js: 5.2.1
@@ -9518,14 +9518,14 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9540,7 +9540,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-ag8ZzpQRoFcs9uvLUTa/QwLTy38SLKNJyCHx0Z9pLurlK+rDqbxqDsgSxMQV8J/xSI4fsojfnIA6nTZSqvoE6w==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-EOdcOrvctM+5zpxnMLjjTfzLhEeqbJshNTxxUo7SmK274svKJAPcejSuRjHXHm5MDa+mpYBMM/QtnUErM1zBGA==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9553,8 +9553,8 @@ packages:
       bluebird: 3.7.2
       browserify-versionify: 1.0.6
       chai: 4.3.4
-      clean-webpack-plugin: 3.0.0_webpack@5.39.1
-      copy-webpack-plugin: 9.0.0_webpack@5.39.1
+      clean-webpack-plugin: 3.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.0_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9564,9 +9564,9 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.39.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -9576,7 +9576,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       pixi.js: 5.2.1
       prettier: 2.3.1
@@ -9585,14 +9585,14 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9607,7 +9607,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-MDDmOBaIyvKcC/JSQjrMbNvvYm7rcMXhJ/1ZW1GpcVUS4SagBabKJBNFA/aB6JK6r8vi1nJIK08qIVmcuwa7mw==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-XSLYGoi6E0oU9V9GGExcD+eX/F3kmNFvLl6O6Pcr+D9rbT6SZl6AF81AU+kz3W7hibqWOfAi17B6KOuzaIk0cw==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9630,8 +9630,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
@@ -9641,7 +9641,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       prettier: 2.3.1
@@ -9651,14 +9651,14 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9673,7 +9673,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-sXqk5qOvh1/VHz+I35EGUqKXpGXg+AMcvVzRx03p2NBul3rR6Eyqy7+UgJXaIhQJyVXt9WKNSoqK0E9IbcA6Xg==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-lbFKTm0LYE44aOh4x2aYt6mnVHKqrxCvl772sHcD3YUjC4xvqazsuGNWCBzJYmMRpXtxY0gZ9SCz+a/QFp97kA==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:
@@ -9696,8 +9696,8 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.39.1
-      istanbul-instrumenter-loader: 3.0.1_webpack@5.39.1
+      imports-loader: 3.0.0_webpack@5.40.0
+      istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
       karma-chrome-launcher: 3.1.0
@@ -9708,7 +9708,7 @@ packages:
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
       karma-sourcemap-loader: 0.3.8
       karma-sourcemap-writer: 0.1.2
-      karma-webpack: 5.0.0_webpack@5.39.1
+      karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       prettier: 2.3.1
@@ -9718,14 +9718,14 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.39.1
-      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.39.1
+      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
       typescript: 4.2.4
-      webpack: 5.39.1_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_7cf21cf02077ec4d39b618ad6a14b03e
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.39.1
+      webpack: 5.40.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1870,7 +1870,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001239
+      caniuse-lite: 1.0.30001240
       colorette: 1.2.2
       electron-to-chromium: 1.3.759
       escalade: 3.1.1
@@ -1969,8 +1969,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /caniuse-lite/1.0.30001239:
-    resolution: {integrity: sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==}
+  /caniuse-lite/1.0.30001240:
+    resolution: {integrity: sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==}
     dev: false
 
   /chai/4.3.4:
@@ -7977,7 +7977,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-jBj4/4umG2zqhan+uSZXQG3hL1QxZnODErjiU2Vv7j8hDCcDapGVTmOmCFylk+y6J4Vs1T+n1HLXkUxoWq+TLA==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-ntwbkS/C9J7RYPd+M0dkDYlEruAsg008cQ8+jkeNQdslZ0pzf8fHXBHoQDBajCryPQ92jBpJBxCP5ttQy2/h6g==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8043,7 +8043,7 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-aY0R6aNXnmMDiPWspbR3HZcZVpYCwY0o5SPUGquSbSn3l/0FF+b4dYDOiCN+16nlYSAJPHFlw3itM1yIVwQp2g==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-0FTiykZwHhQjS9R7a1n5HnbsBbNqdeGYf7o5MKE1PtVd8ew9v7JA+ljMWqzRCZA41BFjPIV2WvdvdGVr894ddg==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
@@ -8111,7 +8111,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-MQIlAbPDp68IX8vGW3oaYxhv5Q+wvLY74o7GhoJFUdPdGqxQ3L3afG/P6higW6nD6OadewNGR/jQx+GiVjc4yg==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-8GzIfOqdWkur8RHc/qN/6Z1SPfVJPnesO8diP+xueWuhL9ofproAvX1sTPB6Fi9b9SazbdNIbfWXzaipuSYjrQ==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8177,7 +8177,7 @@ packages:
     dev: false
 
   file:projects/game-battleship.tgz:
-    resolution: {integrity: sha512-8Y+HHOBZTKDOgg27ahdTUnlBGxGoL7rR61O9+DiNmB9D4XPhrpEC+UtRveJ5Ii7qKi1UGiE41+n2cDKWNIrlkA==, tarball: file:projects/game-battleship.tgz}
+    resolution: {integrity: sha512-LvOAFcHOZdBRnSeMsL2z55Iqgzf9CJreeZpqQu3DkDed1D2Ptya6etZzz2YxKBX3dooYbsb59b2JNx+fQbKFTA==, tarball: file:projects/game-battleship.tgz}
     name: '@rush-temp/game-battleship'
     version: 0.0.0
     dependencies:
@@ -8239,7 +8239,7 @@ packages:
     dev: false
 
   file:projects/game-match3.tgz:
-    resolution: {integrity: sha512-USgfVMA1TJYAxXpecmZ9im5bqiKbeZZl2oyN9cI6zfoECEzLPECS/Ee4f/7xpZ3z7ElqSWq0g2mKjsXUAAKm2w==, tarball: file:projects/game-match3.tgz}
+    resolution: {integrity: sha512-BrLZfjXK84Bjj5ou/zMKGkjmih+ERJSS9etk1Dml7JhUFxCJv/9IFQmz6ErENvYbndSpnDDrZe4awWUgp5mrNw==, tarball: file:projects/game-match3.tgz}
     name: '@rush-temp/game-match3'
     version: 0.0.0
     dependencies:
@@ -8301,7 +8301,7 @@ packages:
     dev: false
 
   file:projects/game-minesweeper.tgz:
-    resolution: {integrity: sha512-M8zSQZzu8yExuSohjW8TyiZ0pMiFK3aqJuzXRjDTDSL0JSeL9AIIhmLM8Sht9d8Vs9fOSzlPSbzwZY52Fuq35g==, tarball: file:projects/game-minesweeper.tgz}
+    resolution: {integrity: sha512-SsMc2SgyBcoxPH412Kj1jEWLOxXzXaW7PzTHMK2BRgiGX+LVufC7vz1W0mRrhaqKcS4fDk7P9MFALGaMsNCJ4g==, tarball: file:projects/game-minesweeper.tgz}
     name: '@rush-temp/game-minesweeper'
     version: 0.0.0
     dependencies:
@@ -8363,7 +8363,7 @@ packages:
     dev: false
 
   file:projects/game-scratchcard.tgz:
-    resolution: {integrity: sha512-+rbpDWhwtH6xleRPvsVAyXUPQttSb26NUISgCbav8nvEaftNM3m5SxP4slsvMTnaj3nKd+1lEkGz3G4xp0DvVg==, tarball: file:projects/game-scratchcard.tgz}
+    resolution: {integrity: sha512-8YzpLQL0rCz20UUPI7mKd/UL4toOmhWnT5HuQ40B6zoltEuKAq5FhkWSN7UgnBIvXulzFbzbyk4Kqnh5GavYqw==, tarball: file:projects/game-scratchcard.tgz}
     name: '@rush-temp/game-scratchcard'
     version: 0.0.0
     dependencies:
@@ -8398,7 +8398,7 @@ packages:
     dev: false
 
   file:projects/game-spaceinvaders.tgz:
-    resolution: {integrity: sha512-VnN3jKswKN6zCgYuGl1rQb/SE73wtNujNppA1Gli7L2dQJjpW52ocuSpHGy/O7tGoEcMkxe0T/8ukP/lCoXL2w==, tarball: file:projects/game-spaceinvaders.tgz}
+    resolution: {integrity: sha512-yM5fCVTXSSxAlnuJAeKqYovHzugGfqDxa9hcuNh8fnEbK1EUC2QU1WaHW1XqMlli+XmrihIClyItRudEmZZEGA==, tarball: file:projects/game-spaceinvaders.tgz}
     name: '@rush-temp/game-spaceinvaders'
     version: 0.0.0
     dependencies:
@@ -8433,7 +8433,7 @@ packages:
     dev: false
 
   file:projects/game-tetris.tgz:
-    resolution: {integrity: sha512-hTRjH1+eGlORo6w140VBQWtvB01DHDBAmo6Ax+jm1xyJlGhery/qee5G73HspAIeGtqbFvJcyY9FaTC5YdRTIg==, tarball: file:projects/game-tetris.tgz}
+    resolution: {integrity: sha512-E5SV/2H/zbVSDIbS+21EcYF0VXqGKhA+HBZnm+/0S843mlPb7ns+PdFWsag+aVnPt4bH+IxWDm7lUM9hTQE1Qg==, tarball: file:projects/game-tetris.tgz}
     name: '@rush-temp/game-tetris'
     version: 0.0.0
     dependencies:
@@ -8476,7 +8476,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-jzDb+m6clETpatYpzhl6I0MVLjJatpHOkVSDgB/hx79PY369mjK9u+KTQJRGhrcQegLvUVSEw/w8BL8T1y6TMg==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-i4kTH3YEFYSp9g7/C4qZ4D1bnlBADI9fpHII9fY2UMzRNbQk2gDViszHBiYFbr5EGauxw7Yd0hRJrwJA/Kvr7A==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8538,7 +8538,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-e6QjuWDkImWBhRAudsyWgewPGPNSbdcT7n9sa8CRlAWbTFblKFPPgEK4aVNxQgdUEcoPklZEWWsD8Bed0g/jIA==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-JFiQ2nmbD3QG1n64NyeAqSTmnekfZVUcpppRauxJrBIfPd+4h2xFGwkXkCld81ht8D2g3082vn/pazus4T3CnQ==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -8600,7 +8600,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-QPAViFWaGzjfzAOXPzKIcT85X7LKA60iIxWqs06SKopcffAT4PnldSe4jqySBEhjttnKjoOtkM0qYKfzVR3Kfw==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-hZvo40VEVGrZqyDCYXFiXr1P3hlzj2dZNc+wZJEzgBu3rvGY3Fx4h08qC82PPW5t06Rz9WCrrHZ9l0FA50Zr9A==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -8663,7 +8663,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-rVucOipnidj8fuqehOtYaXexf1dvmTizL/ts6IJ/5dwZ3zb2kf+tP3p3rMZ8hBzGXB298phOliAmMMs3QtcmxA==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-alL4n4A3B9ybtIYbF6w4kzHVQ0sBHWIdbvUqTQ66jurGyGfiw8225BweqqSqpzRtXM1azEt6zMbQYesDTEX1xQ==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8723,7 +8723,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-XOju3+K2hWxVPxf+c9slyBEELhf2QZwwQQP0bKLgBRTgeLKWrD99PXMNQRcKr1hdmELZzOkgcTSk73lEXe4nNw==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-9cpGlmKtKa+7rGnruCqwv//SARPxGAVevSdx4xeWWXroOPuPf8s4bKj/M1RlOMXYx31P3OYMCNcHLfUn54925Q==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
@@ -8787,7 +8787,7 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-9rGu24ufbpW6p4/FFg7cQvvtgYOgmsZFkxJh1BOOQZtbgqQ5EvbWgFeZjSRpgjM+n943EOUSzVKwmih2KJN5Gg==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-Hd/Luaq4Ovwvf48Egg2zFvdcHrmgVN841hcr66cx0Y6dpO74mEkKKwPKyNNFtUfvdhuZwJcetvXRfieN5Oqpsg==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
@@ -8852,7 +8852,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-Cg4ct3H1c1D5V4UisqhxGK/IhltDM4WdTNsXcEVuYm4ZSsR7FbpPjYflvsqR8XIZCbLADiJhW3Z14CM4pqBMdA==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-A9lLcXJjjuDRuADBYPj8TMpjYMQ/sBDjf/6aJ5eJRaDy7VjW6JqaQWziUAAUxkUfa6BQXh+AViu4xiJquU2omg==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -8915,11 +8915,10 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-gjyj3punm88bbf92xJ/olrUXfcedQySeWqeW1m5fvopPI4ojzWtbFnqaFkN/A2mt5tI4hG0teUOrWeIYOc63cQ==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-7uJfiKFV9rxO3t5L91xthlt9Z/vg9zI+kvjqRuk7SascDwCm8MSIaDTwyKp8ir9pEp9ZLGacmwnrvg1KgXok5A==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
-      '@istanbuljs/nyc-config-typescript': 1.0.1_40f74ebf3b42f8d97356b2262606f547
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
@@ -8947,7 +8946,6 @@ packages:
       karma-sourcemap-writer: 0.1.2
       karma-webpack: 5.0.0_webpack@5.40.0
       mocha: 9.0.1
-      nyc: 15.1.0
       pixi.js: 5.2.1
       prettier: 2.3.1
       puppeteer: 10.0.0
@@ -8978,7 +8976,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-/pJnZH89faSFJPOma7CstCB68eBAyAFVGfxgdbuWauSIpMGYefvpbkeUruha50d7+Cn38D6rcY5v3zk8dp8YFg==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-rHU7+KLDIPg1WzFFlqL0P4C50idNUeodUuwnGEe+t2M6OGqlbP1IgHBoee+g5LoVFjXM1sUWIbYxO+K32WoXTg==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9041,7 +9039,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-BRpbQxhmw8goIROAHv5DQVaofIfYD3qhjRo3Yh+VDe2jg4n+aRE3Z0CxCtv+htes9UbacNuWCrMY9q5kW+OaXg==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-RTmZoZCkjj0DJWNs169wRfd5YpVwbIyzWSRRNoxpkQYdnvHiKlnOAusCbIaQxeC238rKvdIWTCHnDTShuFC9bg==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9103,7 +9101,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-y4O05musOI0jln5xw/mZbLTkAZiSNuaDF7/x/QhSFhK/iXksHfTzNx3Ju9K8k9eM9ehcDQnPKuOk+EOfXFR6tA==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-06XxD1gOBFTp7GybmiDMKD1c+G8R07pJ7l8xErFlgE22UznH4X1G7GtYQ0k9mSPAiyOwtiw2gsJtwP4HPvZ4LA==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -57,7 +57,6 @@ specifiers:
   jsdom-global: ^3.0.2
   karma: ^6.3.4
   karma-chrome-launcher: ^3.1.0
-  karma-commonjs: ^1.0.0
   karma-coverage-istanbul-reporter: ^3.0.3
   karma-es6-shim: ^1.0.0
   karma-mocha: ^2.0.1
@@ -145,7 +144,6 @@ dependencies:
   jsdom-global: 3.0.2_jsdom@16.6.0
   karma: 6.3.4
   karma-chrome-launcher: 3.1.0
-  karma-commonjs: 1.0.0_karma@6.3.4
   karma-coverage-istanbul-reporter: 3.0.3
   karma-es6-shim: 1.0.0
   karma-mocha: 2.0.1
@@ -5147,14 +5145,6 @@ packages:
       which: 1.3.1
     dev: false
 
-  /karma-commonjs/1.0.0_karma@6.3.4:
-    resolution: {integrity: sha1-hoHV19YGYoxfAKNuau88+UPGsKk=}
-    peerDependencies:
-      karma: '>=0.9'
-    dependencies:
-      karma: 6.3.4
-    dev: false
-
   /karma-coverage-istanbul-reporter/3.0.3:
     resolution: {integrity: sha512-wE4VFhG/QZv2Y4CdAYWDbMmcAHeS926ZIji4z+FkB2aF/EposRb6DP6G5ncT/wXhqUfAb/d7kZrNKPonbvsATw==}
     dependencies:
@@ -8508,7 +8498,6 @@ packages:
       jsdom-global: 3.0.2_jsdom@16.6.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
-      karma-commonjs: 1.0.0_karma@6.3.4
       karma-coverage-istanbul-reporter: 3.0.3
       karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -56,7 +56,6 @@ specifiers:
   jsdom: ^16.6.0
   jsdom-global: ^3.0.2
   karma: ^6.3.4
-  karma-chai-sinon: ^0.1.5
   karma-chrome-launcher: ^3.1.0
   karma-commonjs: ^1.0.0
   karma-coverage-istanbul-reporter: ^3.0.3
@@ -95,9 +94,9 @@ dependencies:
   '@rush-temp/core': file:projects/core.tgz
   '@rush-temp/createjs': file:projects/createjs.tgz
   '@rush-temp/eventemitter3': file:projects/eventemitter3.tgz
-  '@rush-temp/game-battleship': file:projects/game-battleship.tgz_sinon-chai@3.7.0
-  '@rush-temp/game-match3': file:projects/game-match3.tgz_sinon-chai@3.7.0
-  '@rush-temp/game-minesweeper': file:projects/game-minesweeper.tgz_sinon-chai@3.7.0
+  '@rush-temp/game-battleship': file:projects/game-battleship.tgz
+  '@rush-temp/game-match3': file:projects/game-match3.tgz
+  '@rush-temp/game-minesweeper': file:projects/game-minesweeper.tgz
   '@rush-temp/game-scratchcard': file:projects/game-scratchcard.tgz
   '@rush-temp/game-spaceinvaders': file:projects/game-spaceinvaders.tgz
   '@rush-temp/game-tetris': file:projects/game-tetris.tgz
@@ -145,7 +144,6 @@ dependencies:
   jsdom: 16.6.0
   jsdom-global: 3.0.2_jsdom@16.6.0
   karma: 6.3.4
-  karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
   karma-chrome-launcher: 3.1.0
   karma-commonjs: 1.0.0_karma@6.3.4
   karma-coverage-istanbul-reporter: 3.0.3
@@ -5143,21 +5141,6 @@ packages:
     resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
     dev: false
 
-  /karma-chai-sinon/0.1.5_5bbab5b1a0990b92afecb710388f2ab5:
-    resolution: {integrity: sha1-XDksqVJHgYlR1rV5AvAsNugDdTo=}
-    engines: {node: '>=0.8'}
-    peerDependencies:
-      chai: '*'
-      karma: '>=0.6'
-      sinon: '*'
-      sinon-chai: '*'
-    dependencies:
-      chai: 4.3.4
-      karma: 6.3.4
-      sinon: 11.1.1
-      sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-    dev: false
-
   /karma-chrome-launcher/3.1.0:
     resolution: {integrity: sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==}
     dependencies:
@@ -8495,7 +8478,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-Pze/6vBtMgmMoJDGb6adMZqqepPAxZ+iVS0szsdR0GnRIWBNI2ePJd0HZvlNAve4V+rmbHY6s/AtuAKvP+rndA==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-V6rbFbzKi4KKIlHa1zNe09oY3UHgFT08a/XD1ktCrm1zkYrx/IRaRmMlk2jRr4B/v9Y9+EQeAxOfBryDjSPyqA==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8566,7 +8549,7 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-ey0wfftnRpWclKRdq+qI5phtMxdhUE+zjLkZJUZkxb/LaySZug4hMm/+EqAX4VoGQy7ib/7P/cQduhiN8f298g==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-94AUCsBIl+hrSaLvI1ozvEH8HlnLefC/VlN2QHDmRw6LrhzYY08NrEhJpdxLh5KqTQmYg8xvXH1zKGyIonGKow==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
@@ -8639,7 +8622,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-qU7eMB0HH+1DYUmgUYNaDNS+dI5DAEWwR5MZDRIf+O+eQrZdV8rcoz6GKP36HWhLDjrr2g+AbkT6MgKmvbYiGw==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-OOn4M7qzx8ApYk67y7cqQbgnG8W9Ov66zMvZXYAxc0falK2Ts+L/Rp2TNq1OO3iEX1eXOJknmp8Cb2XQClko2w==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8708,9 +8691,8 @@ packages:
       - webpack-bundle-analyzer
     dev: false
 
-  file:projects/game-battleship.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-vwU+V8va+4N0SURiPmMvELqfYJBfM9C6LrMcL2C30yHUpNtAbH3GKsBuIqH5EyRsAY6gxDhVja2INX1c9Tztbg==, tarball: file:projects/game-battleship.tgz}
-    id: file:projects/game-battleship.tgz
+  file:projects/game-battleship.tgz:
+    resolution: {integrity: sha512-j5opPbc3hS2a5jemAjnDvlF5yCWasvHsJaiTOklDtb0QYpIa1zHRBDNO1XNuHRW8vK4X2xvQk8xZRrVfBbnWMg==, tarball: file:projects/game-battleship.tgz}
     name: '@rush-temp/game-battleship'
     version: 0.0.0
     dependencies:
@@ -8750,6 +8732,7 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
+      sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
@@ -8766,15 +8749,13 @@ packages:
       - '@webpack-cli/migrate'
       - bufferutil
       - debug
-      - sinon-chai
       - supports-color
       - utf-8-validate
       - webpack-bundle-analyzer
     dev: false
 
-  file:projects/game-match3.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-GV9I0S6YarQzCrtTooP8Eit6W8YpolJzctRY4B9mxvkRDBM/9QatmiQvSxuMmP++WE8S9cb/hXzt7kg36kS96g==, tarball: file:projects/game-match3.tgz}
-    id: file:projects/game-match3.tgz
+  file:projects/game-match3.tgz:
+    resolution: {integrity: sha512-101JQguz4wCYP9IJVzlbZ55bsTIULyvYD01f84dXbYk/xXtIkFUUX7OLiSkFb1a8m08t9Agync1saqSsR3zfiQ==, tarball: file:projects/game-match3.tgz}
     name: '@rush-temp/game-match3'
     version: 0.0.0
     dependencies:
@@ -8814,6 +8795,7 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
+      sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
@@ -8830,15 +8812,13 @@ packages:
       - '@webpack-cli/migrate'
       - bufferutil
       - debug
-      - sinon-chai
       - supports-color
       - utf-8-validate
       - webpack-bundle-analyzer
     dev: false
 
-  file:projects/game-minesweeper.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-WD7v3ekd9qiAcqu1UMYImU47KGjygcw3P0FJmmWHvIZZ981VCJj2UaFVWfc62ka4QO9uYDFyuAIJCK6wMLRA8A==, tarball: file:projects/game-minesweeper.tgz}
-    id: file:projects/game-minesweeper.tgz
+  file:projects/game-minesweeper.tgz:
+    resolution: {integrity: sha512-AWjJyi+KGRh0tmL5dZp1Wn02eM9ARBekXpTG8yHOviAwbsarpEa6wxaBUTFp5TzCswR2+2I/oJr+skN8HVmOFw==, tarball: file:projects/game-minesweeper.tgz}
     name: '@rush-temp/game-minesweeper'
     version: 0.0.0
     dependencies:
@@ -8878,6 +8858,7 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
+      sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
@@ -8894,14 +8875,13 @@ packages:
       - '@webpack-cli/migrate'
       - bufferutil
       - debug
-      - sinon-chai
       - supports-color
       - utf-8-validate
       - webpack-bundle-analyzer
     dev: false
 
   file:projects/game-scratchcard.tgz:
-    resolution: {integrity: sha512-fJChcv9N+ScgzhvQf5h3m7aE9qO9ahbdNsL1m7HN/FOaeYwryrTP5LiT1S9aaxC7rukmojaakbNBpza5LVNUyQ==, tarball: file:projects/game-scratchcard.tgz}
+    resolution: {integrity: sha512-mJGemaZby3KxAk+nstcG0Po8u2U00A9ePWPC9EvfmbNRxsHLfAVNzcGNXId6fsa4KCNlBsC3558gUjojaQ4v/w==, tarball: file:projects/game-scratchcard.tgz}
     name: '@rush-temp/game-scratchcard'
     version: 0.0.0
     dependencies:
@@ -8937,7 +8917,7 @@ packages:
     dev: false
 
   file:projects/game-spaceinvaders.tgz:
-    resolution: {integrity: sha512-W1TYPiEhxyMqRXDV7K2Zv3JHSYYj16CJ7Vdq+rXy5VJQtfJlidIQFFlVQvnFFJsraVmslA1UG7tHwiyFzB5mkA==, tarball: file:projects/game-spaceinvaders.tgz}
+    resolution: {integrity: sha512-cfo0XqwpGEfoHup02EbEx7AO6bZz53BdT4t6bkB0QKEV1FcerrqTd7hGSQevYjDCicIDhwZA5st2Fy+xE98nPQ==, tarball: file:projects/game-spaceinvaders.tgz}
     name: '@rush-temp/game-spaceinvaders'
     version: 0.0.0
     dependencies:
@@ -8973,7 +8953,7 @@ packages:
     dev: false
 
   file:projects/game-tetris.tgz:
-    resolution: {integrity: sha512-hTRjH1+eGlORo6w140VBQWtvB01DHDBAmo6Ax+jm1xyJlGhery/qee5G73HspAIeGtqbFvJcyY9FaTC5YdRTIg==, tarball: file:projects/game-tetris.tgz}
+    resolution: {integrity: sha512-yNGZ94mEb5oWLqoIiMLrYyXiOUxgk5JoMVsSOgKkHBhQ+vNNPSKEJ1K6jvmtL0KSY9e6/B5a50fx+TvAW1mPFw==, tarball: file:projects/game-tetris.tgz}
     name: '@rush-temp/game-tetris'
     version: 0.0.0
     dependencies:
@@ -9016,7 +8996,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-AI/JGe4geDjj8Kn2+8TWmTCLb3Cx1euuk7T1KjwsfC8a47fNRWnpcTqMy6A2OnYqlT1QYGBeIQFjXiDLQv8jzA==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-sykwH4Qd47/rSbp+qWB/CnrHVRO1F3ku3Y5HXC8EH1MqJvCMMDfplh7dImdkixOeEGKJudawlSgjKDrE1Jz+Uw==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9042,7 +9022,6 @@ packages:
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
-      karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
       karma-es6-shim: 1.0.0
@@ -9083,7 +9062,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-yiGAwfaHTzXqelELy+7V+BG/XULuh7FLfbxd6+Y9l4C/wlo78t6UCbjzKP3/ZuHWKplJJqhPMcXsH28331If1g==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-bmwq5Mg+BwCG4bW/2ze8CqXfM0TR+/t3bMrYLGWOzemmQLTFiLWxUC8uzhwWL7WRwtJTF/ghe+ah+ZMMlzwd8w==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -9109,7 +9088,6 @@ packages:
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
-      karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
       karma-es6-shim: 1.0.0
@@ -9150,7 +9128,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-EEOor3jl9gLylnEk1sxuZNHt42SA0sfy5+puPPiCR1rsVXPrYufuPm+B+dXUBG4z2tXIix0UucQl6sEe54B1aQ==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-WhUwa7+uzuatUoMiDStxUuJLXkqsa/c3koVrFNzg6BrOTS/a6B8p74uiskkv7C86k7AXZ5zafg8N4kCQSBGTMw==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -9218,7 +9196,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-DtPDxvmeBhAj34Ast3LbmSi8zZR0EqZE/Na3VtUaCSTtaHc+edL4MWkTPyhZ9X36/CrYGaX3wNcyhBopVfxCKg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-rI7V0U1BBY3mCfrtoHzqg2DSNjnpt2AhrrT/oMM62BBvTGixCSn3eN0QcGbQ8VhRWTa12f3/9gOh3LehprCYcg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9282,7 +9260,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-LIPSALLWN3CrHv/Btf3/nJkc3QGORzRTQBr5NlHxdys9idMbZaZAvd3CoybvXhI+hJvWGYOdj54AHj0MMILaIw==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-VpjOjXDEgwX4M9bw0OiZBD/IKJYLIjZURvNqyvkmlak8ImygN9yRhaTzqc6S/oKEaiPSuSQwnHu54ARfbqEl5w==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
@@ -9350,7 +9328,7 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-DiYJRXDpQrNiJpW52r5O+l9IHbggDKnXiqcmNSCTiC2VKAzIcZSgw+nKriPQciV4+pCmJN6iVJLYMDYcMy9WsQ==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-nEU6sscq0aUH9zutkfcs5Ni7VM4bsFHBy3SabnKRuWwPDYgmouHqvykUrVXd8jtUaz0n7LKFybuTRG4sHaoyjg==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
@@ -9419,7 +9397,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-Otosnbv+IhvifXVhvNdPUNXUEYr5gvnG2AgzuPtNiAtm93aAFSgjbN19ECceOIPUFRHC1/SIZEmfKiho0YJwig==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-w+0KMQMV54bJAVtFVCQNpvhThUJ4l+2cEnYVikmqXAqyWYRoFYy8zwlYqNBo7QZDxYyH1bdkCsOORVlaka8FQA==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -9487,7 +9465,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-MK4vayikuTt82DOFEIHsJp7SV4bXXoO07p19GD7m+hQw1hEYErt7OEnvpLb6jfcJ1cR3rbh+G2DiCom3aR9MhQ==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-eQQj9I2h85UEkDw2ZeE+Sd9HGCl+HdkBsZ8dR1BFaeouxdz2VKz3rNOwoZvCdA9nS9LTO2WM37xszx7QNiT4ow==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -9555,7 +9533,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-V/CZx+kTMdlqcNsz20zSWfW6Nbr51ITRrB24JIe2bsUPw/x6GMaSaRC7hzCF+KmQ5dHlhrHAUH7B2OapCwXZRA==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-E8A81/AH6QOKDebi5TGBVdYHlgBZblesZQaQenC6o2lRDQ2mclIann1y3goCahva1YaBVCWvS9XKXWxJUXd0HQ==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9622,7 +9600,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-qFrIPUSDY2iQkog7IU/fnIAY9rFvjBvtGlhoJ0u7x/HJ7+st9WXm3q/WtEUWesumGBdH4eEi78cHWLGepz1vrQ==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-tuDYSgTJwEbmo3UFYIlMF9wH95+l8Xtv3P8/h6SaN26oPMvhFR9KJC4LEd6lSc/RE1s56mqEjDi2kwJY1IL/DQ==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9688,7 +9666,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-53AQVS539xAi+sEtEJMocpcZO49VG9nP4bRYQfjYuNiVfrHXaTpaE4k5WBySGfOY8DeAB4fNd7mm544GrT3MEw==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-pv4lI6QqEX3vOsQtruGtLEGkT7LxvnySDCvqkdlyDMrN2QXPDcteU+xyAxcNKn8e6cP6rUBetKfdRKXYmmnqig==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:
@@ -9714,7 +9692,6 @@ packages:
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
-      karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
       karma-es6-shim: 1.0.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1362,10 +1362,6 @@ packages:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
     dev: false
 
-  /abbrev/1.0.9:
-    resolution: {integrity: sha1-kbR5JYinc4wl813W9jdSovh3YTU=}
-    dev: false
-
   /accepts/1.3.7:
     resolution: {integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==}
     engines: {node: '>= 0.6'}
@@ -1466,19 +1462,6 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /amdefine/1.0.1:
-    resolution: {integrity: sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=}
-    engines: {node: '>=0.4.2'}
-    dev: false
-    optional: true
-
-  /ansi-colors/1.1.0:
-    resolution: {integrity: sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-wrap: 0.1.0
-    dev: false
-
   /ansi-colors/3.2.4:
     resolution: {integrity: sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==}
     engines: {node: '>=6'}
@@ -1532,11 +1515,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: false
-
-  /ansi-wrap/0.1.0:
-    resolution: {integrity: sha1-qCJQ3bABXponyoLoLqYDu/pF768=}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /anymatch/2.0.0:
@@ -1679,10 +1657,6 @@ packages:
 
   /async-limiter/1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
-    dev: false
-
-  /async/1.5.2:
-    resolution: {integrity: sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=}
     dev: false
 
   /async/2.6.3:
@@ -1931,7 +1905,7 @@ packages:
     dependencies:
       caniuse-lite: 1.0.30001239
       colorette: 1.2.2
-      electron-to-chromium: 1.3.758
+      electron-to-chromium: 1.3.759
       escalade: 3.1.1
       node-releases: 1.1.73
     dev: false
@@ -2479,7 +2453,7 @@ packages:
     dependencies:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
-      whatwg-url: 8.6.0
+      whatwg-url: 8.7.0
     dev: false
 
   /date-format/2.1.0:
@@ -2806,8 +2780,8 @@ packages:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
-  /electron-to-chromium/1.3.758:
-    resolution: {integrity: sha512-StYtiDbgZdjcck3OLwsVVVif7QDuD5m5v2gF+XpETp5lHa7X0y3129YBlYaHRPyj1fep1oAaC6i//gAdp+rhbw==}
+  /electron-to-chromium/1.3.759:
+    resolution: {integrity: sha512-nM76xH0t2FBH5iMEZDVc3S/qbdKjGH7TThezxC8k1Q7w7WHvIAyJh8lAe2UamGfdRqBTjHfPDn82LJ0ksCiB9g==}
     dev: false
 
   /emoji-regex/7.0.3:
@@ -3024,19 +2998,6 @@ packages:
       optionator: 0.8.3
     optionalDependencies:
       source-map: 0.6.1
-    dev: false
-
-  /escodegen/1.8.1:
-    resolution: {integrity: sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=}
-    engines: {node: '>=0.12.0'}
-    hasBin: true
-    dependencies:
-      esprima: 2.7.3
-      estraverse: 1.9.3
-      esutils: 2.0.3
-      optionator: 0.8.3
-    optionalDependencies:
-      source-map: 0.2.0
     dev: false
 
   /escodegen/2.0.0:
@@ -3303,12 +3264,6 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: false
 
-  /esprima/2.7.3:
-    resolution: {integrity: sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dev: false
-
   /esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -3327,11 +3282,6 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.2.0
-    dev: false
-
-  /estraverse/1.9.3:
-    resolution: {integrity: sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /estraverse/4.3.0:
@@ -3902,16 +3852,6 @@ packages:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
     dev: false
 
-  /glob/5.0.15:
-    resolution: {integrity: sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=}
-    dependencies:
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.0.4
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: false
-
   /glob/7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
     dependencies:
@@ -4106,19 +4046,6 @@ packages:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
     dev: false
 
-  /handlebars/4.7.7:
-    resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.5
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.13.9
-    dev: false
-
   /has-ansi/2.0.0:
     resolution: {integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=}
     engines: {node: '>=0.10.0'}
@@ -4128,11 +4055,6 @@ packages:
 
   /has-bigints/1.0.1:
     resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
-    dev: false
-
-  /has-flag/1.0.0:
-    resolution: {integrity: sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /has-flag/3.0.0:
@@ -5013,7 +4935,7 @@ packages:
       webidl-conversions: 6.1.0
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
-      whatwg-url: 8.6.0
+      whatwg-url: 8.7.0
       ws: 7.5.0
       xml-name-validator: 3.0.0
     transitivePeerDependencies:
@@ -5698,13 +5620,6 @@ packages:
     resolution: {integrity: sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==}
     dev: false
 
-  /nopt/3.0.6:
-    resolution: {integrity: sha1-xkZdvwirzU2zWTF/eaxopkayj/k=}
-    hasBin: true
-    dependencies:
-      abbrev: 1.0.9
-    dev: false
-
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
@@ -6292,16 +6207,6 @@ packages:
       find-up: 2.1.0
     dev: false
 
-  /plugin-error/1.0.1:
-    resolution: {integrity: sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      ansi-colors: 1.1.0
-      arr-diff: 4.0.0
-      arr-union: 3.1.0
-      extend-shallow: 3.0.2
-    dev: false
-
   /pluralize/8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -6721,10 +6626,6 @@ packages:
 
   /resolve/0.6.3:
     resolution: {integrity: sha1-3ZV5gufnNt699TtYpN2RdUV13UY=}
-    dev: false
-
-  /resolve/1.1.7:
-    resolution: {integrity: sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=}
     dev: false
 
   /resolve/1.19.0:
@@ -7149,14 +7050,6 @@ packages:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}
     dev: false
 
-  /source-map/0.2.0:
-    resolution: {integrity: sha1-2rc/vPwrqBm03gO9b26qSBZLP50=}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      amdefine: 1.0.1
-    dev: false
-    optional: true
-
   /source-map/0.5.0:
     resolution: {integrity: sha1-D+llA6yGpa213mP05BKuSHLNvoY=}
     engines: {node: '>=0.10.0'}
@@ -7418,13 +7311,6 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /supports-color/3.2.3:
-    resolution: {integrity: sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      has-flag: 1.0.0
-    dev: false
-
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -7564,13 +7450,6 @@ packages:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
     dependencies:
       readable-stream: 2.3.7
-      xtend: 4.0.2
-    dev: false
-
-  /through2/3.0.0:
-    resolution: {integrity: sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==}
-    dependencies:
-      readable-stream: 3.6.0
       xtend: 4.0.2
     dev: false
 
@@ -7792,13 +7671,6 @@ packages:
   /ua-parser-js/0.7.28:
     resolution: {integrity: sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==}
     dev: false
-
-  /uglify-js/3.13.9:
-    resolution: {integrity: sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    dev: false
-    optional: true
 
   /unbox-primitive/1.0.1:
     resolution: {integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==}
@@ -8156,8 +8028,8 @@ packages:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
     dev: false
 
-  /whatwg-url/8.6.0:
-    resolution: {integrity: sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==}
+  /whatwg-url/8.7.0:
+    resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}
     engines: {node: '>=10'}
     dependencies:
       lodash: 4.17.21
@@ -8207,10 +8079,6 @@ packages:
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
-
-  /wordwrap/1.0.0:
-    resolution: {integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=}
     dev: false
 
   /workerpool/6.1.4:
@@ -8340,6 +8208,11 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /yargs-parser/20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+    dev: false
+
   /yargs-unparser/2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
@@ -8392,7 +8265,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.2
       y18n: 5.0.8
-      yargs-parser: 20.2.4
+      yargs-parser: 20.2.9
     dev: false
 
   /yauzl/2.10.0:
@@ -8413,7 +8286,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-V6rbFbzKi4KKIlHa1zNe09oY3UHgFT08a/XD1ktCrm1zkYrx/IRaRmMlk2jRr4B/v9Y9+EQeAxOfBryDjSPyqA==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-VT/UT2f5GUZ7p9ogk+pMQ4jQeUR7d8wEPdM/2tTcbmPgwwReIHGe5YS+gazLBhc9Mig/ohlkWMxDQ/ALwAncaA==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8482,7 +8355,7 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-94AUCsBIl+hrSaLvI1ozvEH8HlnLefC/VlN2QHDmRw6LrhzYY08NrEhJpdxLh5KqTQmYg8xvXH1zKGyIonGKow==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-12YUxLpMV0UefEQfW3DzQVQsP05EEhrCUEqhtg8AnsVFMxM5wqT5i3KUv3gWhYK19mK9Lp9fUu/GPLh7ZLcpSA==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
@@ -8553,7 +8426,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-OOn4M7qzx8ApYk67y7cqQbgnG8W9Ov66zMvZXYAxc0falK2Ts+L/Rp2TNq1OO3iEX1eXOJknmp8Cb2XQClko2w==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-8lvuo8BvWls72tnw6K4mMkL6VarqutKNy9LT+2Bz/oRrq9nSSrpIgUd00eWfuPjEqEcXvt3zT9bTbSCuXSfddA==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8622,7 +8495,7 @@ packages:
     dev: false
 
   file:projects/game-battleship.tgz:
-    resolution: {integrity: sha512-j5opPbc3hS2a5jemAjnDvlF5yCWasvHsJaiTOklDtb0QYpIa1zHRBDNO1XNuHRW8vK4X2xvQk8xZRrVfBbnWMg==, tarball: file:projects/game-battleship.tgz}
+    resolution: {integrity: sha512-8Y+HHOBZTKDOgg27ahdTUnlBGxGoL7rR61O9+DiNmB9D4XPhrpEC+UtRveJ5Ii7qKi1UGiE41+n2cDKWNIrlkA==, tarball: file:projects/game-battleship.tgz}
     name: '@rush-temp/game-battleship'
     version: 0.0.0
     dependencies:
@@ -8684,7 +8557,7 @@ packages:
     dev: false
 
   file:projects/game-match3.tgz:
-    resolution: {integrity: sha512-101JQguz4wCYP9IJVzlbZ55bsTIULyvYD01f84dXbYk/xXtIkFUUX7OLiSkFb1a8m08t9Agync1saqSsR3zfiQ==, tarball: file:projects/game-match3.tgz}
+    resolution: {integrity: sha512-USgfVMA1TJYAxXpecmZ9im5bqiKbeZZl2oyN9cI6zfoECEzLPECS/Ee4f/7xpZ3z7ElqSWq0g2mKjsXUAAKm2w==, tarball: file:projects/game-match3.tgz}
     name: '@rush-temp/game-match3'
     version: 0.0.0
     dependencies:
@@ -8746,7 +8619,7 @@ packages:
     dev: false
 
   file:projects/game-minesweeper.tgz:
-    resolution: {integrity: sha512-AWjJyi+KGRh0tmL5dZp1Wn02eM9ARBekXpTG8yHOviAwbsarpEa6wxaBUTFp5TzCswR2+2I/oJr+skN8HVmOFw==, tarball: file:projects/game-minesweeper.tgz}
+    resolution: {integrity: sha512-M8zSQZzu8yExuSohjW8TyiZ0pMiFK3aqJuzXRjDTDSL0JSeL9AIIhmLM8Sht9d8Vs9fOSzlPSbzwZY52Fuq35g==, tarball: file:projects/game-minesweeper.tgz}
     name: '@rush-temp/game-minesweeper'
     version: 0.0.0
     dependencies:
@@ -8808,7 +8681,7 @@ packages:
     dev: false
 
   file:projects/game-scratchcard.tgz:
-    resolution: {integrity: sha512-mJGemaZby3KxAk+nstcG0Po8u2U00A9ePWPC9EvfmbNRxsHLfAVNzcGNXId6fsa4KCNlBsC3558gUjojaQ4v/w==, tarball: file:projects/game-scratchcard.tgz}
+    resolution: {integrity: sha512-fJChcv9N+ScgzhvQf5h3m7aE9qO9ahbdNsL1m7HN/FOaeYwryrTP5LiT1S9aaxC7rukmojaakbNBpza5LVNUyQ==, tarball: file:projects/game-scratchcard.tgz}
     name: '@rush-temp/game-scratchcard'
     version: 0.0.0
     dependencies:
@@ -8844,7 +8717,7 @@ packages:
     dev: false
 
   file:projects/game-spaceinvaders.tgz:
-    resolution: {integrity: sha512-cfo0XqwpGEfoHup02EbEx7AO6bZz53BdT4t6bkB0QKEV1FcerrqTd7hGSQevYjDCicIDhwZA5st2Fy+xE98nPQ==, tarball: file:projects/game-spaceinvaders.tgz}
+    resolution: {integrity: sha512-W1TYPiEhxyMqRXDV7K2Zv3JHSYYj16CJ7Vdq+rXy5VJQtfJlidIQFFlVQvnFFJsraVmslA1UG7tHwiyFzB5mkA==, tarball: file:projects/game-spaceinvaders.tgz}
     name: '@rush-temp/game-spaceinvaders'
     version: 0.0.0
     dependencies:
@@ -8880,7 +8753,7 @@ packages:
     dev: false
 
   file:projects/game-tetris.tgz:
-    resolution: {integrity: sha512-yNGZ94mEb5oWLqoIiMLrYyXiOUxgk5JoMVsSOgKkHBhQ+vNNPSKEJ1K6jvmtL0KSY9e6/B5a50fx+TvAW1mPFw==, tarball: file:projects/game-tetris.tgz}
+    resolution: {integrity: sha512-hTRjH1+eGlORo6w140VBQWtvB01DHDBAmo6Ax+jm1xyJlGhery/qee5G73HspAIeGtqbFvJcyY9FaTC5YdRTIg==, tarball: file:projects/game-tetris.tgz}
     name: '@rush-temp/game-tetris'
     version: 0.0.0
     dependencies:
@@ -8923,7 +8796,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-sykwH4Qd47/rSbp+qWB/CnrHVRO1F3ku3Y5HXC8EH1MqJvCMMDfplh7dImdkixOeEGKJudawlSgjKDrE1Jz+Uw==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-wymIAm2/injLCYaqrQpwp3KE2ht/XGSKl65qkv7on54cmTmC6QEuwTkLdZdGoAbcH8pqdOVcViCP8YGl55YDyQ==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8988,7 +8861,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-bmwq5Mg+BwCG4bW/2ze8CqXfM0TR+/t3bMrYLGWOzemmQLTFiLWxUC8uzhwWL7WRwtJTF/ghe+ah+ZMMlzwd8w==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-kZB/VI/JoF2UwR1Hza1c/AU6iggF3s8S79+2r2wFI/7e9iWH5vMQzOWaPB1RdxQU7BAv6fFHH5UEEa1O+lgmig==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -9053,7 +8926,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-WhUwa7+uzuatUoMiDStxUuJLXkqsa/c3koVrFNzg6BrOTS/a6B8p74uiskkv7C86k7AXZ5zafg8N4kCQSBGTMw==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-ZFRCPvV72bjL1O6bdNKThBKF9p6t8HoJ+gnfI0XySNS8Vi1VLEfXiZbccfrcQ2kCmZsQZu7JVFw6T47sDgVXsA==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -9120,7 +8993,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-rI7V0U1BBY3mCfrtoHzqg2DSNjnpt2AhrrT/oMM62BBvTGixCSn3eN0QcGbQ8VhRWTa12f3/9gOh3LehprCYcg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-NK1q/y8LG8oPq+WRueXnBN4BvKpGnxQhikwBxWHE9a+sI0yFl7zjxwHU8E8h26kBT0wpuDYZMR6SIMIG6e8XAg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9183,7 +9056,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-VpjOjXDEgwX4M9bw0OiZBD/IKJYLIjZURvNqyvkmlak8ImygN9yRhaTzqc6S/oKEaiPSuSQwnHu54ARfbqEl5w==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-wqOwg8ZoskqkUbYlpXRYo2/qfHWMKWfUhLB1X+du+9pKmnujKJSwIUHefmybUdwAWp9FjyEP8M6kKm6oh4X4Rg==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
@@ -9250,7 +9123,7 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-nEU6sscq0aUH9zutkfcs5Ni7VM4bsFHBy3SabnKRuWwPDYgmouHqvykUrVXd8jtUaz0n7LKFybuTRG4sHaoyjg==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-rH9W2+RJA0ElDxIismVtbf2pFNOwkoBJtCUrLRWrcHrd++QFECQ96kR+unZL5+alVWDYJbAHE/Z3LTRqN+Cclw==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
@@ -9318,7 +9191,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-w+0KMQMV54bJAVtFVCQNpvhThUJ4l+2cEnYVikmqXAqyWYRoFYy8zwlYqNBo7QZDxYyH1bdkCsOORVlaka8FQA==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-ltI5O3MIi8pnN3EzVl/QPWEW4PwFyAYTwtxDv/VsXe4cLsNvO5tQPz5GooBGCJkCi7vpzDxEefbGQ28wcXEcjA==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -9384,7 +9257,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-eQQj9I2h85UEkDw2ZeE+Sd9HGCl+HdkBsZ8dR1BFaeouxdz2VKz3rNOwoZvCdA9nS9LTO2WM37xszx7QNiT4ow==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-8l2O+nLIXJRLhuBYcDMIqx5nRiXX9gDH//hpkWXZVUbFkQmCqd3yEGzE4faATot11D9FaopLYHnF1dE06qW1Uw==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -9450,7 +9323,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-E8A81/AH6QOKDebi5TGBVdYHlgBZblesZQaQenC6o2lRDQ2mclIann1y3goCahva1YaBVCWvS9XKXWxJUXd0HQ==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-dEtTnFvqtE6+GhN3TcUvUnVHO3KNV3MhN2Gt7ezmhAyzal7niamxxqgB1/QxHbywFxpvUeMPno5rpaZO7AsJ5A==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9516,7 +9389,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-tuDYSgTJwEbmo3UFYIlMF9wH95+l8Xtv3P8/h6SaN26oPMvhFR9KJC4LEd6lSc/RE1s56mqEjDi2kwJY1IL/DQ==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-EJW4vuoyGNpzMPTqb+OwhbWrxGezUcBGMSvyAXF/IzQmnLKPCDw7pH2Pdflgpnz+t6hjuzLs/d+47i5BWG4S/Q==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9581,7 +9454,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-pv4lI6QqEX3vOsQtruGtLEGkT7LxvnySDCvqkdlyDMrN2QXPDcteU+xyAxcNKn8e6cP6rUBetKfdRKXYmmnqig==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-pfzZa+CKQ6X/Hl6Trep7hvQ8E5cTPN7Dkj+YWe8bN5UHr1pnwPhUTULOacWD7HsdcJa998h+5bkPsmD/mydxpg==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -50,7 +50,6 @@ specifiers:
   glslify: ^7.1.1
   gsap: ^1.20.6
   html-webpack-plugin: ^5.3.2
-  imports-loader: ^3.0.0
   inversify: ^5.1.1
   istanbul-instrumenter-loader: ^3.0.1
   jsdom: ^16.6.0
@@ -135,7 +134,6 @@ dependencies:
   glslify: 7.1.1
   gsap: 1.20.6
   html-webpack-plugin: 5.3.2_webpack@5.40.0
-  imports-loader: 3.0.0_webpack@5.40.0
   inversify: 5.1.1
   istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
   jsdom: 16.6.0
@@ -4356,17 +4354,6 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /imports-loader/3.0.0_webpack@5.40.0:
-    resolution: {integrity: sha512-PhDB+rxpc95/1cM8ehxWAcuDIDi3eXhqHhax09iyUeAYBJ2bT6QbBp7aDj8IfU9Ns+2l1K226GhoWVAU823CTA==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-    dependencies:
-      source-map: 0.6.1
-      strip-comments: 2.0.1
-      webpack: 5.40.0_webpack-cli@4.7.2
-    dev: false
-
   /imurmurhash/0.1.4:
     resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
     engines: {node: '>=0.8.19'}
@@ -7286,11 +7273,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /strip-comments/2.0.1:
-    resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
-    engines: {node: '>=10'}
-    dev: false
-
   /strip-eof/1.0.0:
     resolution: {integrity: sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=}
     engines: {node: '>=0.10.0'}
@@ -8286,7 +8268,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-VT/UT2f5GUZ7p9ogk+pMQ4jQeUR7d8wEPdM/2tTcbmPgwwReIHGe5YS+gazLBhc9Mig/ohlkWMxDQ/ALwAncaA==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-CfwMtpZzYZDNfQEf9lexaa2XYBDUflQ0btKFCizybl38LtcbPnChCF1OcIaBWqZgn+HA8jy5zJ7fXcF8qpm37g==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8309,7 +8291,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       inversify: 5.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       jsdom: 16.6.0
@@ -8355,7 +8336,7 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-12YUxLpMV0UefEQfW3DzQVQsP05EEhrCUEqhtg8AnsVFMxM5wqT5i3KUv3gWhYK19mK9Lp9fUu/GPLh7ZLcpSA==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-k70/06LnIAmeauaA6J24MevBjwf/lQPJppAKS0WaFAloQgOe7b43bBaoI0Fo+B1De/nQoPV/XinzCwO6hLfdLA==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
@@ -8385,7 +8366,6 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8426,7 +8406,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-8lvuo8BvWls72tnw6K4mMkL6VarqutKNy9LT+2Bz/oRrq9nSSrpIgUd00eWfuPjEqEcXvt3zT9bTbSCuXSfddA==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-xtV+T4HDT0yr0kpUWloeVBtEHIfbiiA1+HU10P7vLRt8WP4BXWiil/IgM74taFMdYrEig809cefXzyMset4PfA==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8450,7 +8430,6 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       eventemitter3: 4.0.7
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       jsdom: 16.6.0
       jsdom-global: 3.0.2_jsdom@16.6.0
@@ -8681,7 +8660,7 @@ packages:
     dev: false
 
   file:projects/game-scratchcard.tgz:
-    resolution: {integrity: sha512-fJChcv9N+ScgzhvQf5h3m7aE9qO9ahbdNsL1m7HN/FOaeYwryrTP5LiT1S9aaxC7rukmojaakbNBpza5LVNUyQ==, tarball: file:projects/game-scratchcard.tgz}
+    resolution: {integrity: sha512-+rbpDWhwtH6xleRPvsVAyXUPQttSb26NUISgCbav8nvEaftNM3m5SxP4slsvMTnaj3nKd+1lEkGz3G4xp0DvVg==, tarball: file:projects/game-scratchcard.tgz}
     name: '@rush-temp/game-scratchcard'
     version: 0.0.0
     dependencies:
@@ -8693,7 +8672,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       pixi.js: 5.2.1
       prettier: 2.3.1
       reflect-metadata: 0.1.13
@@ -8717,7 +8695,7 @@ packages:
     dev: false
 
   file:projects/game-spaceinvaders.tgz:
-    resolution: {integrity: sha512-W1TYPiEhxyMqRXDV7K2Zv3JHSYYj16CJ7Vdq+rXy5VJQtfJlidIQFFlVQvnFFJsraVmslA1UG7tHwiyFzB5mkA==, tarball: file:projects/game-spaceinvaders.tgz}
+    resolution: {integrity: sha512-VnN3jKswKN6zCgYuGl1rQb/SE73wtNujNppA1Gli7L2dQJjpW52ocuSpHGy/O7tGoEcMkxe0T/8ukP/lCoXL2w==, tarball: file:projects/game-spaceinvaders.tgz}
     name: '@rush-temp/game-spaceinvaders'
     version: 0.0.0
     dependencies:
@@ -8729,7 +8707,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       pixi.js: 5.2.1
       prettier: 2.3.1
       reflect-metadata: 0.1.13
@@ -8796,7 +8773,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-wymIAm2/injLCYaqrQpwp3KE2ht/XGSKl65qkv7on54cmTmC6QEuwTkLdZdGoAbcH8pqdOVcViCP8YGl55YDyQ==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-UQcqEolN3zln35cNLz62BgJv5Oa6JPmeiVvy/QCmBSpexyd/rELmN7kV5f6eA5cOKmL8crXH5NqB/TK8UKKsvw==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8819,7 +8796,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8861,7 +8837,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-kZB/VI/JoF2UwR1Hza1c/AU6iggF3s8S79+2r2wFI/7e9iWH5vMQzOWaPB1RdxQU7BAv6fFHH5UEEa1O+lgmig==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-xpMmmA20HADUX/WebBd8F/zFi2GrGqxmGkjck+EUB6jkiFN5ADNIdzgQqXhVB3Cv9G5bp1fknOGO4Q/TT9fEzw==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -8884,7 +8860,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8926,7 +8901,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-ZFRCPvV72bjL1O6bdNKThBKF9p6t8HoJ+gnfI0XySNS8Vi1VLEfXiZbccfrcQ2kCmZsQZu7JVFw6T47sDgVXsA==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-dkQ/uXMLf4N5zsg7H3TRL5kkIobVNC0s8BrxX30dH3OI6ICadQj6quU1E7Q/hqUrGHKDTZuEpVCkwsf1MxJCsw==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -8952,7 +8927,6 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8993,7 +8967,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-NK1q/y8LG8oPq+WRueXnBN4BvKpGnxQhikwBxWHE9a+sI0yFl7zjxwHU8E8h26kBT0wpuDYZMR6SIMIG6e8XAg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-uDvmCj0vp+byG/Yx8oZFnMLgobEx7Ah3n1t/RSsCNktuaCW1j5fcJL5R9QpIttpig6mmzembrWMfEPCldJXGdg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9015,7 +8989,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9056,7 +9029,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-wqOwg8ZoskqkUbYlpXRYo2/qfHWMKWfUhLB1X+du+9pKmnujKJSwIUHefmybUdwAWp9FjyEP8M6kKm6oh4X4Rg==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-8ipCn7Xx0N6BV1feFRDfJnLCAsgQYAODXlt4Y4/hmRq+X2mO/ThOnrJhEZXm/ax1nrexWXEBsaomuiaZwMB9HA==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
@@ -9081,7 +9054,6 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9123,7 +9095,7 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-rH9W2+RJA0ElDxIismVtbf2pFNOwkoBJtCUrLRWrcHrd++QFECQ96kR+unZL5+alVWDYJbAHE/Z3LTRqN+Cclw==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-dud4MniLyyJmGmY8L8FfP6bVnPh8o4BqvW0jssc7rviwQbZCOTBPVKyCacbdN/GEss9LL9UZVNQGLUyYNtOv7A==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
@@ -9149,7 +9121,6 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9191,7 +9162,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-ltI5O3MIi8pnN3EzVl/QPWEW4PwFyAYTwtxDv/VsXe4cLsNvO5tQPz5GooBGCJkCi7vpzDxEefbGQ28wcXEcjA==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-qo05l4DQtdn7MgHnMWI2tYBvdCTjrRGLVBrEPuLAhmKBbvHEm8DEfiSY833tk7bW1jYfsihnAchDVOJb9LnoGw==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -9216,7 +9187,6 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9257,7 +9227,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-8l2O+nLIXJRLhuBYcDMIqx5nRiXX9gDH//hpkWXZVUbFkQmCqd3yEGzE4faATot11D9FaopLYHnF1dE06qW1Uw==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-zf0+uduQ1P19cbx2D19iDKphepgSapbWHyx9xOHeqv3x5KfFtPnz0p4OjahSVgVSKEFHdEgaqV+iYioTrIe0nw==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -9280,7 +9250,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9323,7 +9292,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-dEtTnFvqtE6+GhN3TcUvUnVHO3KNV3MhN2Gt7ezmhAyzal7niamxxqgB1/QxHbywFxpvUeMPno5rpaZO7AsJ5A==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-ZySfPMcR/41oDsSQ3ajV26JHkFb03sEcp76uLGPxYa8+rjPaLN4I8LkQeSo+4k8D5vWz5MPVc1oPzMq5gneZeQ==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9348,7 +9317,6 @@ packages:
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9389,7 +9357,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-EJW4vuoyGNpzMPTqb+OwhbWrxGezUcBGMSvyAXF/IzQmnLKPCDw7pH2Pdflgpnz+t6hjuzLs/d+47i5BWG4S/Q==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-k91KvYc9Vnu+dQgbqJk4W7j7k3CTqwGNwcw732/T19HyGeUCEsF9d2k/kXc7qRGM1iDuxeaYkFUI6ocMTtWMyw==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9412,7 +9380,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9454,7 +9421,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-pfzZa+CKQ6X/Hl6Trep7hvQ8E5cTPN7Dkj+YWe8bN5UHr1pnwPhUTULOacWD7HsdcJa998h+5bkPsmD/mydxpg==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-/LIqmtFsJ+vCfexryi1iu4HIP28BBKluqQkjdzatz7440XTOwHaP4rUn0ifLm+HdAC4tJJrImfIOnirr51YqNA==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:
@@ -9477,7 +9444,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -43,7 +43,7 @@ specifiers:
   es6-symbol: ^3.1.3
   eslint: ^7.29.0
   eslint-plugin-import: ^2.23.4
-  eslint-plugin-jsdoc: ^35.3.2
+  eslint-plugin-jsdoc: ^35.4.0
   eslint-plugin-prefer-arrow: ^1.2.3
   eslint-plugin-react: ^7.24.0
   eslint-plugin-unicorn: ^33.0.1
@@ -133,7 +133,7 @@ dependencies:
   es6-symbol: 3.1.3
   eslint: 7.29.0
   eslint-plugin-import: 2.23.4_eslint@7.29.0
-  eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+  eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
   eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
   eslint-plugin-react: 7.24.0_eslint@7.29.0
   eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -3095,8 +3095,8 @@ packages:
       tsconfig-paths: 3.9.0
     dev: false
 
-  /eslint-plugin-jsdoc/35.3.2_eslint@7.29.0:
-    resolution: {integrity: sha512-r3qfbByMZ4O5Y8O6aHxo1AdgdpwTQSD72anIZuhjNI6ZkMtjhpSkkPN3cY/tsZtmWeMH+1pB/nblWIAr3F0lxA==}
+  /eslint-plugin-jsdoc/35.4.0_eslint@7.29.0:
+    resolution: {integrity: sha512-0cr+NkPTxpTiMCtYOd8W5fd2IyC/CmaTHKb+0bzkpP9p8HfmJ3B2/M6FWj97rQJOLwLMkx+g2MIEZsrttpbFmQ==}
     engines: {node: '>=12'}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
@@ -8479,7 +8479,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-ZRuGmyFCU2fYomhILk/PwjVPd5+PNrf4ZVYyu7byAeiN+EaIEvrPwOV0NvkcpIP29RMmdu8EBpgAlTN13J0fww==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-rkf7QOJEwxTJ+zQiS6I0iUEtjAvCuDpwiNOBoqJB0MBYk6MRMiSb118cnW0PBT1sbnCV4WFXR37/RjqasVbQSw==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8497,7 +8497,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8550,7 +8550,7 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-Nd64dhtGrFVISFwUtfLhr2w5lyZR4P0omD4GrKTptJwkF7lSZEAc9DhtGQGDPHTm/CaE3uPeWFMSNOYMAwzIhw==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-rNM5Z2l/jcRLHyhDJW8MS2T3T9E8DA2AIHMgUp2y6xlz3n/fd9+LLkFgftfc4DYhxAqJi9yDv5xIcC/0pMyH+A==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
@@ -8574,7 +8574,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8623,7 +8623,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-G/jvdzcDR9JLA60YKU641Qml7mnQFJN1O9BgvJB9Uh7dPfoWACWxZgmqjFCF9Ypa6u5Iv7WCiCd9UVVA4xQ+Ww==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-laqEDMAxi6FrpUqUjKn9uodIZZwrPfaQi37p4Se8Tp2f1Kph8XXxZrWLJZz70WI58pzbA5b6KeCyriIPKeW1eA==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8641,7 +8641,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8693,7 +8693,7 @@ packages:
     dev: false
 
   file:projects/game-battleship.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-AOhvnPNyh8vTQfxswnXNKww9i14aXCNObMXBmPY0gZkU2V1QZKWlEnXiAH7ZGBwBk2e5v6ge3DRh5Oi0jycytw==, tarball: file:projects/game-battleship.tgz}
+    resolution: {integrity: sha512-R0uMJRP42ZFXHBSitCkVEb/n6QkIRszOtLTeEAoOsekGqK7OVFez1xUkQrUFO62dKp8H+UmytmvpWS6E/sW+HQ==, tarball: file:projects/game-battleship.tgz}
     id: file:projects/game-battleship.tgz
     name: '@rush-temp/game-battleship'
     version: 0.0.0
@@ -8710,7 +8710,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8757,7 +8757,7 @@ packages:
     dev: false
 
   file:projects/game-match3.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-Wv0wJZuTf7XBsqaZfZ8BHEyCy9hNnOaMR+xS9iaJUXN9+tYz6t/5PaG+tIPTfFJ4MYmOGHIQpqrBEFIFg+Nvxg==, tarball: file:projects/game-match3.tgz}
+    resolution: {integrity: sha512-mkCwLQxIbP0nZYIxq1VUa1t6JEvMYWW9ybZKX28Cp9YKgKc53xMmdzQ59hRkiNuv/uhZOK0usy8cSrJMUMYdAg==, tarball: file:projects/game-match3.tgz}
     id: file:projects/game-match3.tgz
     name: '@rush-temp/game-match3'
     version: 0.0.0
@@ -8774,7 +8774,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8821,7 +8821,7 @@ packages:
     dev: false
 
   file:projects/game-minesweeper.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-SsPFnLzTgJ8hXRjc+aBFDFepukmGwmdJf1XDOrvWwn+zdfyfLq02tDNjWHALJKrLXQMSIwDW9lBTtYVx04fbEQ==, tarball: file:projects/game-minesweeper.tgz}
+    resolution: {integrity: sha512-uQNnTtO2v/M9mzj7mUblzH1aTSAGbU0pfeKIeXq27qhRRbgWHdenRg20teYR2FYLPY5Cg930kXQRRZ07SRRIKw==, tarball: file:projects/game-minesweeper.tgz}
     id: file:projects/game-minesweeper.tgz
     name: '@rush-temp/game-minesweeper'
     version: 0.0.0
@@ -8838,7 +8838,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8885,14 +8885,14 @@ packages:
     dev: false
 
   file:projects/game-scratchcard.tgz:
-    resolution: {integrity: sha512-D8DNBWDwM52biI7Mjnh0/PcMlSR1tWvkimj/LLLofDGpj5lPlfBm0FAPUl8EdSMiL3vjVu5SDj9Uxzdzg1KklQ==, tarball: file:projects/game-scratchcard.tgz}
+    resolution: {integrity: sha512-asw+VASXc84fz5nzM2vU0JCKQbnODB8maXAH3X6cFzDRNgcI/UliTttKdg1su0uJxouHmzE69JlVrvSvOO4vww==, tarball: file:projects/game-scratchcard.tgz}
     name: '@rush-temp/game-scratchcard'
     version: 0.0.0
     dependencies:
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8921,14 +8921,14 @@ packages:
     dev: false
 
   file:projects/game-spaceinvaders.tgz:
-    resolution: {integrity: sha512-RokAzspCPJ12cC8y00VKEIh81av+YdQ6yR076OmytvkhfzHA4JSfo351VSEd1k+8n6l1zeRA8oUe5mOfmr6P0Q==, tarball: file:projects/game-spaceinvaders.tgz}
+    resolution: {integrity: sha512-x7MFwh1uazUDu3B1Xk1UWU2u6E/Ryn1QGp1YWI/riIBcWN/lqYycffxi+IfV006Pdtid3MaJBXaaRV73vMCiTA==, tarball: file:projects/game-spaceinvaders.tgz}
     name: '@rush-temp/game-spaceinvaders'
     version: 0.0.0
     dependencies:
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -8957,7 +8957,7 @@ packages:
     dev: false
 
   file:projects/game-tetris.tgz:
-    resolution: {integrity: sha512-eSYGabMSTXNlrzqXstEFovsZ6OobttlnRnd8eAABlV8FJVI0m0cql319F7cjPQoWlu057NfbMswwxR2V3kwA/A==, tarball: file:projects/game-tetris.tgz}
+    resolution: {integrity: sha512-Z5UCD/FKeH4r0JJmQCcLaRB0wkAIrqM2WHV7s5TqsS3fMbwhbPHmpfwE7t4E2FW4Hi9X1LcvqRvk3t6x8+/Vyg==, tarball: file:projects/game-tetris.tgz}
     name: '@rush-temp/game-tetris'
     version: 0.0.0
     dependencies:
@@ -8969,7 +8969,7 @@ packages:
       chai: 4.3.4
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9000,7 +9000,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-DlI4PTDqCNwIzC1ggvY9uZfynZaNxsWPgNg5hGCEmec4b1agso89BA0rrzyPSRwkYAg9CVMkxzQWCJnoZzLZhQ==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-ZdWO5luPTtBHhbEnOQBdW6EfNXnLuDMrXQYiGC+ErcD+wBwdlNWo7T6UQeCgG712gZTL5foVEtfomwHfbyKV1w==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9018,7 +9018,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9067,7 +9067,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-TiKdBToEcI1gJauyYcuImLliWOytfFbSIZT023Bj9ofeFRIGMN8YLWyzsvAPNqptJ9K21og+thxgn+IgYo9W9g==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-TPthr22zlJruyzXAE5ghShmNG+tSYcswoo0kcMBFXkrly06HeS0TZPsxARziF5awUZpoP5ECONXhvovcR1MjPw==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -9085,7 +9085,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9134,7 +9134,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-jv4OWFwFOxJqY/9T6gapCP+2cL6bzoC3Ri05z/3a4QWzRbGfdJIuyA/FkzGXyRJ5HG80DTCs+08VXTCRvuzn+w==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-Uohsq+gcB17LFFQLq8hXI4Gy1KnAsyzXWh7TUs8cOib9PA8bWYNBIe0I7iVUVjzwyd8L6njcMVNCtzXgXK5s1w==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -9154,7 +9154,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9202,7 +9202,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-nC8vWksEtNqnxzBBgFgOjee51+SKAsAOpIxmfB2k+68f+iGWV72NFIJbokiCyPdxn7u0KIHkiugLR9XhO2O3hw==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-oqwakuWoWeVEoev3ikvm5WUjXS7eHKLxfMLXBPWzqU0aRFJWwlIDQPQ26wia8yT45H1QLneeGXK114jRyBBc6Q==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9219,7 +9219,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9266,7 +9266,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-2ZZcJjVa4u8XES+iLTdvXRecnoYLWCxfGPu8lDEaWvI0SBjKVLjO0Plwhed8Mh/Sdk2auSd64bvUy9+nAaHaVw==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-45d0zs0DxJbuRyJboXCbe+hGAslSnAEbB4KNUuaNU8N+q/OlFOfWP9zrzNu/d0BmoWVJz98aseT/yqtrVbcUew==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
@@ -9285,7 +9285,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9334,7 +9334,7 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-UV/ekt1O3Of3qPvq9S46bABYj/RCjWNCmxD+g9F/qDMWPUj8oWP2ePkkvKTHF8YAGMk+ZwwEI326LjtEVS4qqQ==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-/YG5Ik/jEdiRcZc9xeHmbZlAWTUEmaTeReHrNa+e4Mi/wH5/cu7tQ5klvsjlkki8e+d19bzRE32ZqbvZjOf+Dw==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
@@ -9354,7 +9354,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9403,7 +9403,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-ovZCW2lv4Y8EiaobZeFzD/gB8Dd0WRKmfuhHI/LTApYP7y8T0aAoPwVB2OKZbN+61O7lCtpziAIRkQWH9XH+XQ==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-niPr/hNUGXZGb8e51/KAk4fRExBd5G7/alFCdw3axFlKof8S/rWwhpniGD4gOEMgf8xe/WQ+89mFWG5fE1W6cw==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -9422,7 +9422,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9471,7 +9471,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-zUvUOQjHrnU5wrRu6baMGmEbFOWm11sTUswmUKlyCOZiXsAHPmQK09/Oo1PzYWhqGQd4AlsndGZNoBdVT/QrKA==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-mNc0SIHwYhrNlX85aYV8r48G8wbt/iyEM/wVIGEszNljZ8dHTtdAsKvAf1NQ5uAt5tFeXpzX7qDdQa1xmLGFUg==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -9489,7 +9489,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9540,7 +9540,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-EOdcOrvctM+5zpxnMLjjTfzLhEeqbJshNTxxUo7SmK274svKJAPcejSuRjHXHm5MDa+mpYBMM/QtnUErM1zBGA==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-BDYp/rhLd2NIgJRogzJOM/ffebJhZn6YSH4bpDuejQ/f+fgzYwtelgUmG/bj9LBJsENGOo7miCXy335Ux4gfpQ==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9559,7 +9559,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9607,7 +9607,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-XSLYGoi6E0oU9V9GGExcD+eX/F3kmNFvLl6O6Pcr+D9rbT6SZl6AF81AU+kz3W7hibqWOfAi17B6KOuzaIk0cw==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-TODuFoyCHiclEBF9+UFY/zM12JrReeimq/OPanI4qnhYQdQtczlZYkyNmsU/1zTlQy0/yc4HFG13+WseIO333g==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9625,7 +9625,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
@@ -9673,7 +9673,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-lbFKTm0LYE44aOh4x2aYt6mnVHKqrxCvl772sHcD3YUjC4xvqazsuGNWCBzJYmMRpXtxY0gZ9SCz+a/QFp97kA==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-o8DUpcxDBjlVijG6jqzBrAhyRv+X64YtCUy/k8UQhzbsrbKuwL8RqM35NZcjZ4LeTxN7bIxzDJvga3YGkmqURQ==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:
@@ -9691,7 +9691,7 @@ packages:
       es6-symbol: 3.1.3
       eslint: 7.29.0
       eslint-plugin-import: 2.23.4_eslint@7.29.0
-      eslint-plugin-jsdoc: 35.3.2_eslint@7.29.0
+      eslint-plugin-jsdoc: 35.4.0_eslint@7.29.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -58,7 +58,6 @@ specifiers:
   karma: ^6.3.4
   karma-chrome-launcher: ^3.1.0
   karma-coverage-istanbul-reporter: ^3.0.3
-  karma-es6-shim: ^1.0.0
   karma-mocha: ^2.0.1
   karma-mocha-reporter: ^2.2.5
   karma-sinon-chai: ^2.0.2
@@ -145,7 +144,6 @@ dependencies:
   karma: 6.3.4
   karma-chrome-launcher: 3.1.0
   karma-coverage-istanbul-reporter: 3.0.3
-  karma-es6-shim: 1.0.0
   karma-mocha: 2.0.1
   karma-mocha-reporter: 2.2.5_karma@6.3.4
   karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -2947,11 +2945,6 @@ packages:
       next-tick: 1.0.0
     dev: false
 
-  /es5-shim/4.5.15:
-    resolution: {integrity: sha512-FYpuxEjMeDvU4rulKqFdukQyZSTpzhg4ScQHrAosrlVpR6GFyaw14f74yn2+4BugniIS0Frpg7TvwZocU4ZMTw==}
-    engines: {node: '>=0.4.0'}
-    dev: false
-
   /es6-error/4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
     dev: false
@@ -2987,10 +2980,6 @@ packages:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
       event-emitter: 0.3.5
-    dev: false
-
-  /es6-shim/0.35.6:
-    resolution: {integrity: sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==}
     dev: false
 
   /es6-symbol/3.1.1:
@@ -5155,13 +5144,6 @@ packages:
       minimatch: 3.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /karma-es6-shim/1.0.0:
-    resolution: {integrity: sha1-qutTCGK895NA69WI9PnlfehCtHk=}
-    dependencies:
-      es5-shim: 4.5.15
-      es6-shim: 0.35.6
     dev: false
 
   /karma-mocha-reporter/2.2.5_karma@6.3.4:
@@ -8499,7 +8481,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -8573,7 +8554,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -8642,7 +8622,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -8707,7 +8686,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -8770,7 +8748,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -8833,7 +8810,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9013,7 +8989,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9079,7 +9054,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9148,7 +9122,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9212,7 +9185,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9279,7 +9251,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9348,7 +9319,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9416,7 +9386,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9482,7 +9451,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9552,7 +9520,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9617,7 +9584,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd
@@ -9683,7 +9649,6 @@ packages:
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
       karma-coverage-istanbul-reporter: 3.0.3
-      karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.4
       karma-sinon-chai: 2.0.2_603bade0eb2595e5f78e5d6c505e52bd

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -72,7 +72,6 @@ specifiers:
   prettier: ^2.3.1
   puppeteer: ^10.0.0
   reflect-metadata: ^0.1.13
-  remap-istanbul: ^0.13.0
   rimraf: ^3.0.2
   sinon: ^11.1.1
   sinon-chai: ^3.7.0
@@ -158,7 +157,6 @@ dependencies:
   prettier: 2.3.1
   puppeteer: 10.0.0
   reflect-metadata: 0.1.13
-  remap-istanbul: 0.13.0
   rimraf: 3.0.2
   sinon: 11.1.1
   sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
@@ -4933,30 +4931,6 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: false
 
-  /istanbul/0.4.5:
-    resolution: {integrity: sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=}
-    deprecated: |-
-      This module is no longer maintained, try this instead:
-        npm i nyc
-      Visit https://istanbul.js.org/integrations for other alternatives.
-    hasBin: true
-    dependencies:
-      abbrev: 1.0.9
-      async: 1.5.2
-      escodegen: 1.8.1
-      esprima: 2.7.3
-      glob: 5.0.15
-      handlebars: 4.7.7
-      js-yaml: 3.14.1
-      mkdirp: 0.5.5
-      nopt: 3.0.6
-      once: 1.4.0
-      resolve: 1.1.7
-      supports-color: 3.2.3
-      which: 1.3.1
-      wordwrap: 1.0.0
-    dev: false
-
   /jest-worker/27.0.2:
     resolution: {integrity: sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==}
     engines: {node: '>= 10.13.0'}
@@ -6656,17 +6630,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       es6-error: 4.1.1
-    dev: false
-
-  /remap-istanbul/0.13.0:
-    resolution: {integrity: sha512-rS5ZpVAx3fGtKZkiBe1esXg5mKYbgW9iz8kkADFt3p6lo3NsBBUX1q6SwdhwUtYCGnr7nK6gRlbYK3i8R0jbRA==}
-    hasBin: true
-    dependencies:
-      istanbul: 0.4.5
-      minimatch: 3.0.4
-      plugin-error: 1.0.1
-      source-map: 0.6.1
-      through2: 3.0.0
     dev: false
 
   /remove-trailing-separator/1.1.0:
@@ -8564,7 +8527,6 @@ packages:
       prettier: 2.3.1
       puppeteer: 10.0.0
       reflect-metadata: 0.1.13
-      remap-istanbul: 0.13.0
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
@@ -9397,7 +9359,6 @@ packages:
       prettier: 2.3.1
       puppeteer: 10.0.0
       reflect-metadata: 0.1.13
-      remap-istanbul: 0.13.0
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
@@ -9463,7 +9424,6 @@ packages:
       prettier: 2.3.1
       puppeteer: 10.0.0
       reflect-metadata: 0.1.13
-      remap-istanbul: 0.13.0
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -37,7 +37,7 @@ specifiers:
   browserify-versionify: ^1.0.6
   chai: ^4.3.4
   clean-webpack-plugin: ^3.0.0
-  copy-webpack-plugin: ^9.0.0
+  copy-webpack-plugin: ^9.0.1
   easeljs: ^1.0.2
   es6-map: ^0.1.5
   es6-symbol: ^3.1.3
@@ -49,7 +49,7 @@ specifiers:
   eslint-plugin-unicorn: ^33.0.1
   glslify: ^7.1.1
   gsap: ^1.20.6
-  html-webpack-plugin: ^5.3.1
+  html-webpack-plugin: ^5.3.2
   imports-loader: ^3.0.0
   inversify: ^5.1.1
   istanbul-instrumenter-loader: ^3.0.1
@@ -59,7 +59,6 @@ specifiers:
   karma-chai-sinon: ^0.1.5
   karma-chrome-launcher: ^3.1.0
   karma-commonjs: ^1.0.0
-  karma-coverage: ^2.0.3
   karma-coverage-istanbul-reporter: ^3.0.3
   karma-es6-shim: ^1.0.0
   karma-mocha: ^2.0.1
@@ -81,7 +80,7 @@ specifiers:
   sinon: ^11.1.1
   sinon-chai: ^3.7.0
   source-map-support: ^0.5.19
-  terser-webpack-plugin: ^5.1.3
+  terser-webpack-plugin: ^5.1.4
   ts-loader: ^9.2.3
   ts-node: ^10.0.0
   tslib: ^2.2.0
@@ -92,7 +91,7 @@ specifiers:
 
 dependencies:
   '@istanbuljs/nyc-config-typescript': 1.0.1_40f74ebf3b42f8d97356b2262606f547
-  '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
+  '@mcler/webpack-concat-plugin': 4.1.3_d4c3353c3f85b77e9d7d7497be421c09
   '@rush-temp/core': file:projects/core.tgz
   '@rush-temp/createjs': file:projects/createjs.tgz
   '@rush-temp/eventemitter3': file:projects/eventemitter3.tgz
@@ -127,7 +126,7 @@ dependencies:
   browserify-versionify: 1.0.6
   chai: 4.3.4
   clean-webpack-plugin: 3.0.0_webpack@5.40.0
-  copy-webpack-plugin: 9.0.0_webpack@5.40.0
+  copy-webpack-plugin: 9.0.1_webpack@5.40.0
   easeljs: 1.0.2
   es6-map: 0.1.5
   es6-symbol: 3.1.3
@@ -139,7 +138,7 @@ dependencies:
   eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
   glslify: 7.1.1
   gsap: 1.20.6
-  html-webpack-plugin: 5.3.1_webpack@5.40.0
+  html-webpack-plugin: 5.3.2_webpack@5.40.0
   imports-loader: 3.0.0_webpack@5.40.0
   inversify: 5.1.1
   istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
@@ -149,7 +148,6 @@ dependencies:
   karma-chai-sinon: 0.1.5_5bbab5b1a0990b92afecb710388f2ab5
   karma-chrome-launcher: 3.1.0
   karma-commonjs: 1.0.0_karma@6.3.4
-  karma-coverage: 2.0.3
   karma-coverage-istanbul-reporter: 3.0.3
   karma-es6-shim: 1.0.0
   karma-mocha: 2.0.1
@@ -171,7 +169,7 @@ dependencies:
   sinon: 11.1.1
   sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
   source-map-support: 0.5.19
-  terser-webpack-plugin: 5.1.3_webpack@5.40.0
+  terser-webpack-plugin: 5.1.4_webpack@5.40.0
   ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
   ts-node: 10.0.0_typescript@4.2.4
   tslib: 2.2.0
@@ -195,25 +193,25 @@ packages:
       '@babel/highlight': 7.14.5
     dev: false
 
-  /@babel/compat-data/7.14.5:
-    resolution: {integrity: sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==}
+  /@babel/compat-data/7.14.7:
+    resolution: {integrity: sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/core/7.14.5:
-    resolution: {integrity: sha512-RN/AwP2DJmQTZSfiDaD+JQQ/J99KsIpOCfBE5pL+5jJSt7nI3nYGoAXZu+ffYSQ029NLs2DstZb+eR81uuARgg==}
+  /@babel/core/7.14.6:
+    resolution: {integrity: sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.14.5
       '@babel/generator': 7.14.5
-      '@babel/helper-compilation-targets': 7.14.5_@babel+core@7.14.5
+      '@babel/helper-compilation-targets': 7.14.5_@babel+core@7.14.6
       '@babel/helper-module-transforms': 7.14.5
-      '@babel/helpers': 7.14.5
-      '@babel/parser': 7.14.5
+      '@babel/helpers': 7.14.6
+      '@babel/parser': 7.14.7
       '@babel/template': 7.14.5
-      '@babel/traverse': 7.14.5
+      '@babel/traverse': 7.14.7
       '@babel/types': 7.14.5
-      convert-source-map: 1.7.0
+      convert-source-map: 1.8.0
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.2.0
@@ -223,14 +221,14 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/eslint-parser/7.14.5_@babel+core@7.14.5+eslint@7.29.0:
-    resolution: {integrity: sha512-20BlOHuGf3UXS7z1QPyllM9Gz8SEgcp/UcKeUmdHIFZO6HF1n+3KaLpeyfwWvjY/Os/ynPX3k8qXE/nZ5dw/0g==}
+  /@babel/eslint-parser/7.14.7_@babel+core@7.14.6+eslint@7.29.0:
+    resolution: {integrity: sha512-6WPwZqO5priAGIwV6msJcdc9TsEPzYeYdS/Xuoap+/ihkgN6dzHp2bcAAwyWZ5bLzk0vvjDmKvRwkqNaiJ8BiQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': '>=7.11.0'
       eslint: '>=7.5.0'
     dependencies:
-      '@babel/core': 7.14.5
+      '@babel/core': 7.14.6
       eslint: 7.29.0
       eslint-scope: 5.1.1
       eslint-visitor-keys: 2.1.0
@@ -246,14 +244,14 @@ packages:
       source-map: 0.5.7
     dev: false
 
-  /@babel/helper-compilation-targets/7.14.5_@babel+core@7.14.5:
+  /@babel/helper-compilation-targets/7.14.5_@babel+core@7.14.6:
     resolution: {integrity: sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.14.5
-      '@babel/core': 7.14.5
+      '@babel/compat-data': 7.14.7
+      '@babel/core': 7.14.6
       '@babel/helper-validator-option': 7.14.5
       browserslist: 4.16.6
       semver: 6.3.0
@@ -282,8 +280,8 @@ packages:
       '@babel/types': 7.14.5
     dev: false
 
-  /@babel/helper-member-expression-to-functions/7.14.5:
-    resolution: {integrity: sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==}
+  /@babel/helper-member-expression-to-functions/7.14.7:
+    resolution: {integrity: sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.14.5
@@ -306,7 +304,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.14.5
       '@babel/helper-validator-identifier': 7.14.5
       '@babel/template': 7.14.5
-      '@babel/traverse': 7.14.5
+      '@babel/traverse': 7.14.7
       '@babel/types': 7.14.5
     transitivePeerDependencies:
       - supports-color
@@ -323,9 +321,9 @@ packages:
     resolution: {integrity: sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-member-expression-to-functions': 7.14.5
+      '@babel/helper-member-expression-to-functions': 7.14.7
       '@babel/helper-optimise-call-expression': 7.14.5
-      '@babel/traverse': 7.14.5
+      '@babel/traverse': 7.14.7
       '@babel/types': 7.14.5
     transitivePeerDependencies:
       - supports-color
@@ -355,12 +353,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helpers/7.14.5:
-    resolution: {integrity: sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==}
+  /@babel/helpers/7.14.6:
+    resolution: {integrity: sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.14.5
-      '@babel/traverse': 7.14.5
+      '@babel/traverse': 7.14.7
       '@babel/types': 7.14.5
     transitivePeerDependencies:
       - supports-color
@@ -375,8 +373,8 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
-  /@babel/parser/7.14.5:
-    resolution: {integrity: sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==}
+  /@babel/parser/7.14.7:
+    resolution: {integrity: sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dev: false
@@ -386,12 +384,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.14.5
-      '@babel/parser': 7.14.5
+      '@babel/parser': 7.14.7
       '@babel/types': 7.14.5
     dev: false
 
-  /@babel/traverse/7.14.5:
-    resolution: {integrity: sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==}
+  /@babel/traverse/7.14.7:
+    resolution: {integrity: sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.14.5
@@ -399,7 +397,7 @@ packages:
       '@babel/helper-function-name': 7.14.5
       '@babel/helper-hoist-variables': 7.14.5
       '@babel/helper-split-export-declaration': 7.14.5
-      '@babel/parser': 7.14.5
+      '@babel/parser': 7.14.7
       '@babel/types': 7.14.5
       debug: 4.3.1
       globals: 11.12.0
@@ -427,13 +425,13 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: false
 
-  /@es-joy/jsdoccomment/0.8.0-alpha.2:
-    resolution: {integrity: sha512-fjRY13Bh8sxDZkzO27U2R9L6xFqkh5fAbHuMGvGLXLfrTes8nTTMyOi6wIPt+CG0XPAxEUge8cDjhG+0aag6ew==}
+  /@es-joy/jsdoccomment/0.8.0:
+    resolution: {integrity: sha512-Xd3GzYsL2sz2pcdtYt5Q0Wz1ol/o9Nt2UQL4nFPDcaEomvPmwjJsbjkKx1SKhl2h3TgwazNBLdcNr2m0UiGiFA==}
     engines: {node: '>=10.0.0'}
     dependencies:
       comment-parser: 1.1.5
       esquery: 1.4.0
-      jsdoc-type-pratt-parser: 1.0.0-alpha.23
+      jsdoc-type-pratt-parser: 1.0.4
     dev: false
 
   /@eslint/eslintrc/0.4.2:
@@ -483,7 +481,7 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /@mcler/webpack-concat-plugin/4.1.3_526cece0d5c3279c7eb6f6ca6be02a57:
+  /@mcler/webpack-concat-plugin/4.1.3_d4c3353c3f85b77e9d7d7497be421c09:
     resolution: {integrity: sha512-usy0VPy7afO58etf4Ln7RXH09USOfd6H5DaXiXqvDOuFuCIacpLcuBDJpjxgEatA8F12ht886Yd5xZwKki/dkQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -492,7 +490,7 @@ packages:
       webpack-sources: ^2.2.0
     dependencies:
       globby: 8.0.2
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       schema-utils: 3.0.0
       upath: 2.0.1
       webpack: 5.40.0_webpack-cli@4.7.2
@@ -926,8 +924,8 @@ packages:
     resolution: {integrity: sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==}
     dev: false
 
-  /@tsconfig/node12/1.0.8:
-    resolution: {integrity: sha512-LM6XwBhjZRls1qJGpiM/It09SntEwe9M0riXRfQ9s6XlJQG0JPGl92ET18LtGeYh/GuOtafIXqwZeqLOd0FNFQ==}
+  /@tsconfig/node12/1.0.9:
+    resolution: {integrity: sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==}
     dev: false
 
   /@tsconfig/node14/1.0.1:
@@ -999,7 +997,7 @@ packages:
     resolution: {integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==}
     dependencies:
       '@types/minimatch': 3.0.4
-      '@types/node': 15.12.2
+      '@types/node': 15.12.4
     dev: false
 
   /@types/html-minifier-terser/5.1.1:
@@ -1022,8 +1020,8 @@ packages:
     resolution: {integrity: sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==}
     dev: false
 
-  /@types/node/15.12.2:
-    resolution: {integrity: sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==}
+  /@types/node/15.12.4:
+    resolution: {integrity: sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==}
     dev: false
 
   /@types/normalize-package-data/2.4.0:
@@ -1063,7 +1061,7 @@ packages:
   /@types/webpack-sources/2.1.0:
     resolution: {integrity: sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==}
     dependencies:
-      '@types/node': 15.12.2
+      '@types/node': 15.12.4
       '@types/source-list-map': 0.1.2
       source-map: 0.7.3
     dev: false
@@ -1071,7 +1069,7 @@ packages:
   /@types/webpack/4.41.29:
     resolution: {integrity: sha512-6pLaORaVNZxiB3FSHbyBiWM7QdazAWda1zvAq4SbZObZqHSDbWLi62iFdblVea6SK9eyBIVp5yHhKt/yNQdR7Q==}
     dependencies:
-      '@types/node': 15.12.2
+      '@types/node': 15.12.4
       '@types/tapable': 1.0.7
       '@types/uglify-js': 3.13.0
       '@types/webpack-sources': 2.1.0
@@ -1082,7 +1080,7 @@ packages:
   /@types/yauzl/2.9.1:
     resolution: {integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==}
     dependencies:
-      '@types/node': 15.12.2
+      '@types/node': 15.12.4
     dev: false
     optional: true
 
@@ -1102,7 +1100,7 @@ packages:
       debug: 4.3.1
       eslint: 7.29.0
       functional-red-black-tree: 1.0.1
-      regexpp: 3.1.0
+      regexpp: 3.2.0
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.2.4
       typescript: 4.2.4
@@ -1410,8 +1408,8 @@ packages:
     hasBin: true
     dev: false
 
-  /acorn/8.4.0:
-    resolution: {integrity: sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==}
+  /acorn/8.4.1:
+    resolution: {integrity: sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: false
@@ -1939,9 +1937,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001236
+      caniuse-lite: 1.0.30001239
       colorette: 1.2.2
-      electron-to-chromium: 1.3.752
+      electron-to-chromium: 1.3.758
       escalade: 3.1.1
       node-releases: 1.1.73
     dev: false
@@ -2038,8 +2036,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /caniuse-lite/1.0.30001236:
-    resolution: {integrity: sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==}
+  /caniuse-lite/1.0.30001239:
+    resolution: {integrity: sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==}
     dev: false
 
   /chai/4.3.4:
@@ -2116,6 +2114,21 @@ packages:
       is-glob: 4.0.1
       normalize-path: 3.0.0
       readdirp: 3.5.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
+  /chokidar/3.5.2:
+    resolution: {integrity: sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.1
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
@@ -2344,8 +2357,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /convert-source-map/1.7.0:
-    resolution: {integrity: sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==}
+  /convert-source-map/1.8.0:
+    resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
     dependencies:
       safe-buffer: 5.1.2
     dev: false
@@ -2369,19 +2382,19 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /copy-webpack-plugin/9.0.0_webpack@5.40.0:
-    resolution: {integrity: sha512-k8UB2jLIb1Jip2nZbCz83T/XfhfjX6mB1yLJNYKrpYi7FQimfOoFv/0//iT6HV1K8FwUB5yUbCcnpLebJXJTug==}
+  /copy-webpack-plugin/9.0.1_webpack@5.40.0:
+    resolution: {integrity: sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.1.0
     dependencies:
       fast-glob: 3.2.5
       glob-parent: 6.0.0
-      globby: 11.0.3
+      globby: 11.0.4
       normalize-path: 3.0.0
       p-limit: 3.1.0
       schema-utils: 3.0.0
-      serialize-javascript: 5.0.1
+      serialize-javascript: 6.0.0
       webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
 
@@ -2547,8 +2560,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /decimal.js/10.2.1:
-    resolution: {integrity: sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==}
+  /decimal.js/10.3.1:
+    resolution: {integrity: sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==}
     dev: false
 
   /decode-uri-component/0.2.0:
@@ -2801,8 +2814,8 @@ packages:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
-  /electron-to-chromium/1.3.752:
-    resolution: {integrity: sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==}
+  /electron-to-chromium/1.3.758:
+    resolution: {integrity: sha512-StYtiDbgZdjcck3OLwsVVVif7QDuD5m5v2gF+XpETp5lHa7X0y3129YBlYaHRPyj1fep1oAaC6i//gAdp+rhbw==}
     dev: false
 
   /emoji-regex/7.0.3:
@@ -3101,7 +3114,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
-      '@es-joy/jsdoccomment': 0.8.0-alpha.2
+      '@es-joy/jsdoccomment': 0.8.0
       comment-parser: 1.1.5
       debug: 4.3.1
       eslint: 7.29.0
@@ -3213,8 +3226,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      '@babel/core': 7.14.5
-      '@babel/eslint-parser': 7.14.5_@babel+core@7.14.5+eslint@7.29.0
+      '@babel/core': 7.14.6
+      '@babel/eslint-parser': 7.14.7_@babel+core@7.14.6+eslint@7.29.0
       eslint: 7.29.0
       eslint-visitor-keys: 2.1.0
       esquery: 1.4.0
@@ -3287,7 +3300,7 @@ packages:
       natural-compare: 1.4.0
       optionator: 0.9.1
       progress: 2.0.3
-      regexpp: 3.1.0
+      regexpp: 3.2.0
       semver: 7.3.5
       strip-ansi: 6.0.0
       strip-json-comments: 3.1.1
@@ -3944,8 +3957,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /globby/11.0.3:
-    resolution: {integrity: sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==}
+  /globby/11.0.4:
+    resolution: {integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==}
     engines: {node: '>=10'}
     dependencies:
       array-union: 2.1.0
@@ -4251,8 +4264,8 @@ packages:
       terser: 4.8.0
     dev: false
 
-  /html-webpack-plugin/5.3.1_webpack@5.40.0:
-    resolution: {integrity: sha512-rZsVvPXUYFyME0cuGkyOHfx9hmkFa4pWfxY/mdY38PsBEaVNsRoA+Id+8z6DBDgyv3zaw6XQszdF8HLwfQvcdQ==}
+  /html-webpack-plugin/5.3.2_webpack@5.40.0:
+    resolution: {integrity: sha512-HvB33boVNCz2lTyBsSiMffsJ+m0YLIQ+pskblXgN9fnjS1BgEcuAfdInfXfGrkdXV406k9FiDi86eVCDBgJOyQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       webpack: ^5.20.0
@@ -4260,7 +4273,7 @@ packages:
       '@types/html-minifier-terser': 5.1.1
       html-minifier-terser: 5.1.1
       lodash: 4.17.21
-      pretty-error: 2.1.2
+      pretty-error: 3.0.4
       tapable: 2.2.0
       webpack: 5.40.0_webpack-cli@4.7.2
     dev: false
@@ -4829,7 +4842,7 @@ packages:
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      convert-source-map: 1.7.0
+      convert-source-map: 1.8.0
       istanbul-lib-instrument: 1.10.2
       loader-utils: 1.4.0
       schema-utils: 0.3.0
@@ -4873,7 +4886,7 @@ packages:
     resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.14.5
+      '@babel/core': 7.14.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -4963,7 +4976,7 @@ packages:
     resolution: {integrity: sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 15.12.2
+      '@types/node': 15.12.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -4995,10 +5008,6 @@ packages:
       argparse: 2.0.1
     dev: false
 
-  /jsdoc-type-pratt-parser/1.0.0-alpha.23:
-    resolution: {integrity: sha512-COtimMd97eo5W0h6R9ISFj9ufg/9EiAzVAeQpKBJ1xJs/x8znWE155HGBDR2rwOuZsCes1gBXGmFVfvRZxGrhg==}
-    dev: false
-
   /jsdoc-type-pratt-parser/1.0.4:
     resolution: {integrity: sha512-jzmW9gokeq9+bHPDR1nCeidMyFUikdZlbOhKzh9+/nJqB75XhpNKec1/UuxW5c4+O+Pi31Gc/dCboyfSm/pSpQ==}
     engines: {node: '>=12.0.0'}
@@ -5022,12 +5031,12 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.5
-      acorn: 8.4.0
+      acorn: 8.4.1
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
       data-urls: 2.0.0
-      decimal.js: 10.2.1
+      decimal.js: 10.3.1
       domexception: 2.0.1
       escodegen: 2.0.0
       form-data: 3.0.1
@@ -5046,7 +5055,7 @@ packages:
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.6.0
-      ws: 7.4.6
+      ws: 7.5.0
       xml-name-validator: 3.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -5175,20 +5184,6 @@ packages:
       - supports-color
     dev: false
 
-  /karma-coverage/2.0.3:
-    resolution: {integrity: sha512-atDvLQqvPcLxhED0cmXYdsPMCQuh6Asa9FMZW1bhNqlVEhJoB9qyZ2BY1gu7D/rr5GLGb5QzYO4siQskxaWP/g==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      istanbul-lib-coverage: 3.0.0
-      istanbul-lib-instrument: 4.0.3
-      istanbul-lib-report: 3.0.0
-      istanbul-lib-source-maps: 4.0.0
-      istanbul-reports: 3.0.2
-      minimatch: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /karma-es6-shim/1.0.0:
     resolution: {integrity: sha1-qutTCGK895NA69WI9PnlfehCtHk=}
     dependencies:
@@ -5256,7 +5251,7 @@ packages:
     dependencies:
       body-parser: 1.19.0
       braces: 3.0.2
-      chokidar: 3.5.1
+      chokidar: 3.5.2
       colors: 1.4.0
       connect: 3.7.0
       di: 0.0.1
@@ -5834,7 +5829,7 @@ packages:
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       caching-transform: 4.0.0
-      convert-source-map: 1.7.0
+      convert-source-map: 1.8.0
       decamelize: 1.2.0
       find-cache-dir: 3.3.1
       find-up: 4.1.0
@@ -6413,8 +6408,8 @@ packages:
     hasBin: true
     dev: false
 
-  /pretty-error/2.1.2:
-    resolution: {integrity: sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==}
+  /pretty-error/3.0.4:
+    resolution: {integrity: sha512-ytLFLfv1So4AO1UkoBF6GXQgJRaKbiSiGFICaOPNwQ3CMvBvXpLRubeQWyPGnsbV/t9ml9qto6IeCsho0aEvwQ==}
     dependencies:
       lodash: 4.17.21
       renderkid: 2.0.7
@@ -6643,6 +6638,13 @@ packages:
       picomatch: 2.3.0
     dev: false
 
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.0
+    dev: false
+
   /rechoir/0.7.0:
     resolution: {integrity: sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==}
     engines: {node: '>= 0.10'}
@@ -6679,8 +6681,8 @@ packages:
       define-properties: 1.1.3
     dev: false
 
-  /regexpp/3.1.0:
-    resolution: {integrity: sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==}
+  /regexpp/3.2.0:
+    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
     dev: false
 
@@ -6983,6 +6985,12 @@ packages:
       randombytes: 2.1.0
     dev: false
 
+  /serialize-javascript/6.0.0:
+    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: false
+
   /serve-index/1.9.1:
     resolution: {integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=}
     engines: {node: '>= 0.8.0'}
@@ -7166,7 +7174,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.0
       '@types/cors': 2.8.10
-      '@types/node': 15.12.2
+      '@types/node': 15.12.4
       accepts: 1.3.7
       base64id: 2.0.0
       debug: 4.3.1
@@ -7568,8 +7576,8 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
-  /terser-webpack-plugin/5.1.3_webpack@5.40.0:
-    resolution: {integrity: sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==}
+  /terser-webpack-plugin/5.1.4_webpack@5.40.0:
+    resolution: {integrity: sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       webpack: ^5.1.0
@@ -7577,7 +7585,7 @@ packages:
       jest-worker: 27.0.2
       p-limit: 3.1.0
       schema-utils: 3.0.0
-      serialize-javascript: 5.0.1
+      serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.7.0
       webpack: 5.40.0_webpack-cli@4.7.2
@@ -7758,7 +7766,7 @@ packages:
         optional: true
     dependencies:
       '@tsconfig/node10': 1.0.8
-      '@tsconfig/node12': 1.0.8
+      '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.1
       arg: 4.1.3
@@ -8185,7 +8193,7 @@ packages:
       '@webassemblyjs/ast': 1.11.0
       '@webassemblyjs/wasm-edit': 1.11.0
       '@webassemblyjs/wasm-parser': 1.11.0
-      acorn: 8.4.0
+      acorn: 8.4.1
       browserslist: 4.16.6
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.8.2
@@ -8200,7 +8208,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.0.0
       tapable: 2.2.0
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       watchpack: 2.2.0
       webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
       webpack-sources: 2.3.0
@@ -8350,6 +8358,19 @@ packages:
         optional: true
     dev: false
 
+  /ws/7.5.0:
+    resolution: {integrity: sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /xml-name-validator/3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
     dev: false
@@ -8398,11 +8419,6 @@ packages:
 
   /yargs-parser/20.2.4:
     resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
-    engines: {node: '>=10'}
-    dev: false
-
-  /yargs-parser/20.2.7:
-    resolution: {integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==}
     engines: {node: '>=10'}
     dev: false
 
@@ -8458,7 +8474,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.2
       y18n: 5.0.8
-      yargs-parser: 20.2.7
+      yargs-parser: 20.2.4
     dev: false
 
   /yauzl/2.10.0:
@@ -8479,7 +8495,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-rkf7QOJEwxTJ+zQiS6I0iUEtjAvCuDpwiNOBoqJB0MBYk6MRMiSb118cnW0PBT1sbnCV4WFXR37/RjqasVbQSw==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-Pze/6vBtMgmMoJDGb6adMZqqepPAxZ+iVS0szsdR0GnRIWBNI2ePJd0HZvlNAve4V+rmbHY6s/AtuAKvP+rndA==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8527,7 +8543,7 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8550,11 +8566,11 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-rNM5Z2l/jcRLHyhDJW8MS2T3T9E8DA2AIHMgUp2y6xlz3n/fd9+LLkFgftfc4DYhxAqJi9yDv5xIcC/0pMyH+A==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-ey0wfftnRpWclKRdq+qI5phtMxdhUE+zjLkZJUZkxb/LaySZug4hMm/+EqAX4VoGQy7ib/7P/cQduhiN8f298g==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
-      '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
+      '@mcler/webpack-concat-plugin': 4.1.3_d4c3353c3f85b77e9d7d7497be421c09
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
@@ -8568,7 +8584,7 @@ packages:
       browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
-      copy-webpack-plugin: 9.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.1_webpack@5.40.0
       easeljs: 1.0.2
       es6-map: 0.1.5
       es6-symbol: 3.1.3
@@ -8579,7 +8595,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -8600,7 +8616,7 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8623,7 +8639,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-laqEDMAxi6FrpUqUjKn9uodIZZwrPfaQi37p4Se8Tp2f1Kph8XXxZrWLJZz70WI58pzbA5b6KeCyriIPKeW1eA==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-qU7eMB0HH+1DYUmgUYNaDNS+dI5DAEWwR5MZDRIf+O+eQrZdV8rcoz6GKP36HWhLDjrr2g+AbkT6MgKmvbYiGw==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8670,7 +8686,7 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8693,7 +8709,7 @@ packages:
     dev: false
 
   file:projects/game-battleship.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-R0uMJRP42ZFXHBSitCkVEb/n6QkIRszOtLTeEAoOsekGqK7OVFez1xUkQrUFO62dKp8H+UmytmvpWS6E/sW+HQ==, tarball: file:projects/game-battleship.tgz}
+    resolution: {integrity: sha512-vwU+V8va+4N0SURiPmMvELqfYJBfM9C6LrMcL2C30yHUpNtAbH3GKsBuIqH5EyRsAY6gxDhVja2INX1c9Tztbg==, tarball: file:projects/game-battleship.tgz}
     id: file:projects/game-battleship.tgz
     name: '@rush-temp/game-battleship'
     version: 0.0.0
@@ -8715,7 +8731,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       gsap: 1.20.6
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8734,7 +8750,7 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8757,7 +8773,7 @@ packages:
     dev: false
 
   file:projects/game-match3.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-mkCwLQxIbP0nZYIxq1VUa1t6JEvMYWW9ybZKX28Cp9YKgKc53xMmdzQ59hRkiNuv/uhZOK0usy8cSrJMUMYdAg==, tarball: file:projects/game-match3.tgz}
+    resolution: {integrity: sha512-GV9I0S6YarQzCrtTooP8Eit6W8YpolJzctRY4B9mxvkRDBM/9QatmiQvSxuMmP++WE8S9cb/hXzt7kg36kS96g==, tarball: file:projects/game-match3.tgz}
     id: file:projects/game-match3.tgz
     name: '@rush-temp/game-match3'
     version: 0.0.0
@@ -8779,7 +8795,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       gsap: 1.20.6
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8798,7 +8814,7 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8821,7 +8837,7 @@ packages:
     dev: false
 
   file:projects/game-minesweeper.tgz_sinon-chai@3.7.0:
-    resolution: {integrity: sha512-uQNnTtO2v/M9mzj7mUblzH1aTSAGbU0pfeKIeXq27qhRRbgWHdenRg20teYR2FYLPY5Cg930kXQRRZ07SRRIKw==, tarball: file:projects/game-minesweeper.tgz}
+    resolution: {integrity: sha512-WD7v3ekd9qiAcqu1UMYImU47KGjygcw3P0FJmmWHvIZZ981VCJj2UaFVWfc62ka4QO9uYDFyuAIJCK6wMLRA8A==, tarball: file:projects/game-minesweeper.tgz}
     id: file:projects/game-minesweeper.tgz
     name: '@rush-temp/game-minesweeper'
     version: 0.0.0
@@ -8843,7 +8859,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       gsap: 1.20.6
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8862,7 +8878,7 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       sinon: 11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8885,7 +8901,7 @@ packages:
     dev: false
 
   file:projects/game-scratchcard.tgz:
-    resolution: {integrity: sha512-asw+VASXc84fz5nzM2vU0JCKQbnODB8maXAH3X6cFzDRNgcI/UliTttKdg1su0uJxouHmzE69JlVrvSvOO4vww==, tarball: file:projects/game-scratchcard.tgz}
+    resolution: {integrity: sha512-fJChcv9N+ScgzhvQf5h3m7aE9qO9ahbdNsL1m7HN/FOaeYwryrTP5LiT1S9aaxC7rukmojaakbNBpza5LVNUyQ==, tarball: file:projects/game-scratchcard.tgz}
     name: '@rush-temp/game-scratchcard'
     version: 0.0.0
     dependencies:
@@ -8896,13 +8912,13 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       pixi.js: 5.2.1
       prettier: 2.3.1
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8921,7 +8937,7 @@ packages:
     dev: false
 
   file:projects/game-spaceinvaders.tgz:
-    resolution: {integrity: sha512-x7MFwh1uazUDu3B1Xk1UWU2u6E/Ryn1QGp1YWI/riIBcWN/lqYycffxi+IfV006Pdtid3MaJBXaaRV73vMCiTA==, tarball: file:projects/game-spaceinvaders.tgz}
+    resolution: {integrity: sha512-W1TYPiEhxyMqRXDV7K2Zv3JHSYYj16CJ7Vdq+rXy5VJQtfJlidIQFFlVQvnFFJsraVmslA1UG7tHwiyFzB5mkA==, tarball: file:projects/game-spaceinvaders.tgz}
     name: '@rush-temp/game-spaceinvaders'
     version: 0.0.0
     dependencies:
@@ -8932,13 +8948,13 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       pixi.js: 5.2.1
       prettier: 2.3.1
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -8957,7 +8973,7 @@ packages:
     dev: false
 
   file:projects/game-tetris.tgz:
-    resolution: {integrity: sha512-Z5UCD/FKeH4r0JJmQCcLaRB0wkAIrqM2WHV7s5TqsS3fMbwhbPHmpfwE7t4E2FW4Hi9X1LcvqRvk3t6x8+/Vyg==, tarball: file:projects/game-tetris.tgz}
+    resolution: {integrity: sha512-hTRjH1+eGlORo6w140VBQWtvB01DHDBAmo6Ax+jm1xyJlGhery/qee5G73HspAIeGtqbFvJcyY9FaTC5YdRTIg==, tarball: file:projects/game-tetris.tgz}
     name: '@rush-temp/game-tetris'
     version: 0.0.0
     dependencies:
@@ -8973,7 +8989,7 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       mocha: 9.0.1
       nyc: 15.1.0
       pixi.js: 5.2.1
@@ -8981,7 +8997,7 @@ packages:
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9000,7 +9016,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-ZdWO5luPTtBHhbEnOQBdW6EfNXnLuDMrXQYiGC+ErcD+wBwdlNWo7T6UQeCgG712gZTL5foVEtfomwHfbyKV1w==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-AI/JGe4geDjj8Kn2+8TWmTCLb3Cx1euuk7T1KjwsfC8a47fNRWnpcTqMy6A2OnYqlT1QYGBeIQFjXiDLQv8jzA==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9045,7 +9061,7 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9067,7 +9083,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-TPthr22zlJruyzXAE5ghShmNG+tSYcswoo0kcMBFXkrly06HeS0TZPsxARziF5awUZpoP5ECONXhvovcR1MjPw==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-yiGAwfaHTzXqelELy+7V+BG/XULuh7FLfbxd6+Y9l4C/wlo78t6UCbjzKP3/ZuHWKplJJqhPMcXsH28331If1g==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -9112,7 +9128,7 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9134,7 +9150,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-Uohsq+gcB17LFFQLq8hXI4Gy1KnAsyzXWh7TUs8cOib9PA8bWYNBIe0I7iVUVjzwyd8L6njcMVNCtzXgXK5s1w==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-EEOor3jl9gLylnEk1sxuZNHt42SA0sfy5+puPPiCR1rsVXPrYufuPm+B+dXUBG4z2tXIix0UucQl6sEe54B1aQ==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -9149,7 +9165,7 @@ packages:
       browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
-      copy-webpack-plugin: 9.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.1_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9159,7 +9175,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9180,7 +9196,7 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9202,7 +9218,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-oqwakuWoWeVEoev3ikvm5WUjXS7eHKLxfMLXBPWzqU0aRFJWwlIDQPQ26wia8yT45H1QLneeGXK114jRyBBc6Q==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-DtPDxvmeBhAj34Ast3LbmSi8zZR0EqZE/Na3VtUaCSTtaHc+edL4MWkTPyhZ9X36/CrYGaX3wNcyhBopVfxCKg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9244,7 +9260,7 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9266,11 +9282,11 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-45d0zs0DxJbuRyJboXCbe+hGAslSnAEbB4KNUuaNU8N+q/OlFOfWP9zrzNu/d0BmoWVJz98aseT/yqtrVbcUew==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-LIPSALLWN3CrHv/Btf3/nJkc3QGORzRTQBr5NlHxdys9idMbZaZAvd3CoybvXhI+hJvWGYOdj54AHj0MMILaIw==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
-      '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
+      '@mcler/webpack-concat-plugin': 4.1.3_d4c3353c3f85b77e9d7d7497be421c09
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
@@ -9290,7 +9306,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9311,7 +9327,7 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9334,11 +9350,11 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-/YG5Ik/jEdiRcZc9xeHmbZlAWTUEmaTeReHrNa+e4Mi/wH5/cu7tQ5klvsjlkki8e+d19bzRE32ZqbvZjOf+Dw==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-DiYJRXDpQrNiJpW52r5O+l9IHbggDKnXiqcmNSCTiC2VKAzIcZSgw+nKriPQciV4+pCmJN6iVJLYMDYcMy9WsQ==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
-      '@mcler/webpack-concat-plugin': 4.1.3_526cece0d5c3279c7eb6f6ca6be02a57
+      '@mcler/webpack-concat-plugin': 4.1.3_d4c3353c3f85b77e9d7d7497be421c09
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
@@ -9349,7 +9365,7 @@ packages:
       browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
-      copy-webpack-plugin: 9.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.1_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9359,7 +9375,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9380,7 +9396,7 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9403,7 +9419,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-niPr/hNUGXZGb8e51/KAk4fRExBd5G7/alFCdw3axFlKof8S/rWwhpniGD4gOEMgf8xe/WQ+89mFWG5fE1W6cw==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-Otosnbv+IhvifXVhvNdPUNXUEYr5gvnG2AgzuPtNiAtm93aAFSgjbN19ECceOIPUFRHC1/SIZEmfKiho0YJwig==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -9417,7 +9433,7 @@ packages:
       browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
-      copy-webpack-plugin: 9.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.1_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9427,7 +9443,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9449,7 +9465,7 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9471,7 +9487,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-mNc0SIHwYhrNlX85aYV8r48G8wbt/iyEM/wVIGEszNljZ8dHTtdAsKvAf1NQ5uAt5tFeXpzX7qDdQa1xmLGFUg==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-MK4vayikuTt82DOFEIHsJp7SV4bXXoO07p19GD7m+hQw1hEYErt7OEnvpLb6jfcJ1cR3rbh+G2DiCom3aR9MhQ==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -9498,7 +9514,6 @@ packages:
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
-      karma-coverage: 2.0.3
       karma-coverage-istanbul-reporter: 3.0.3
       karma-es6-shim: 1.0.0
       karma-mocha: 2.0.1
@@ -9518,7 +9533,7 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9540,7 +9555,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-BDYp/rhLd2NIgJRogzJOM/ffebJhZn6YSH4bpDuejQ/f+fgzYwtelgUmG/bj9LBJsENGOo7miCXy335Ux4gfpQ==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-V/CZx+kTMdlqcNsz20zSWfW6Nbr51ITRrB24JIe2bsUPw/x6GMaSaRC7hzCF+KmQ5dHlhrHAUH7B2OapCwXZRA==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9554,7 +9569,7 @@ packages:
       browserify-versionify: 1.0.6
       chai: 4.3.4
       clean-webpack-plugin: 3.0.0_webpack@5.40.0
-      copy-webpack-plugin: 9.0.0_webpack@5.40.0
+      copy-webpack-plugin: 9.0.1_webpack@5.40.0
       es6-map: 0.1.5
       es6-symbol: 3.1.3
       eslint: 7.29.0
@@ -9564,7 +9579,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       glslify: 7.1.1
-      html-webpack-plugin: 5.3.1_webpack@5.40.0
+      html-webpack-plugin: 5.3.2_webpack@5.40.0
       imports-loader: 3.0.0_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9585,7 +9600,7 @@ packages:
       rimraf: 3.0.2
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9607,7 +9622,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-TODuFoyCHiclEBF9+UFY/zM12JrReeimq/OPanI4qnhYQdQtczlZYkyNmsU/1zTlQy0/yc4HFG13+WseIO333g==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-qFrIPUSDY2iQkog7IU/fnIAY9rFvjBvtGlhoJ0u7x/HJ7+st9WXm3q/WtEUWesumGBdH4eEi78cHWLGepz1vrQ==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9651,7 +9666,7 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0
@@ -9673,7 +9688,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-o8DUpcxDBjlVijG6jqzBrAhyRv+X64YtCUy/k8UQhzbsrbKuwL8RqM35NZcjZ4LeTxN7bIxzDJvga3YGkmqURQ==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-53AQVS539xAi+sEtEJMocpcZO49VG9nP4bRYQfjYuNiVfrHXaTpaE4k5WBySGfOY8DeAB4fNd7mm544GrT3MEw==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:
@@ -9718,7 +9733,7 @@ packages:
       sinon: 11.1.1
       sinon-chai: 3.7.0_chai@4.3.4+sinon@11.1.1
       source-map-support: 0.5.19
-      terser-webpack-plugin: 5.1.3_webpack@5.40.0
+      terser-webpack-plugin: 5.1.4_webpack@5.40.0
       ts-loader: 9.2.3_typescript@4.2.4+webpack@5.40.0
       ts-node: 10.0.0_typescript@4.2.4
       tslib: 2.2.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -47,7 +47,6 @@ specifiers:
   eslint-plugin-prefer-arrow: ^1.2.3
   eslint-plugin-react: ^7.24.0
   eslint-plugin-unicorn: ^33.0.1
-  glslify: ^7.1.1
   gsap: ^1.20.6
   html-webpack-plugin: ^5.3.2
   inversify: ^5.1.1
@@ -131,7 +130,6 @@ dependencies:
   eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
   eslint-plugin-react: 7.24.0_eslint@7.29.0
   eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-  glslify: 7.1.1
   gsap: 1.20.6
   html-webpack-plugin: 5.3.2_webpack@5.40.0
   inversify: 5.1.1
@@ -401,13 +399,6 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.14.5
       to-fast-properties: 2.0.0
-    dev: false
-
-  /@choojs/findup/0.2.1:
-    resolution: {integrity: sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==}
-    hasBin: true
-    dependencies:
-      commander: 2.20.3
     dev: false
 
   /@discoveryjs/json-ext/0.5.3:
@@ -1801,13 +1792,6 @@ packages:
     dev: false
     optional: true
 
-  /bl/2.2.1:
-    resolution: {integrity: sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==}
-    dependencies:
-      readable-stream: 2.3.7
-      safe-buffer: 5.2.1
-    dev: false
-
   /bl/4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -2284,16 +2268,6 @@ packages:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: false
 
-  /concat-stream/1.6.2:
-    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
-    engines: {'0': node >= 0.8}
-    dependencies:
-      buffer-from: 1.1.1
-      inherits: 2.0.4
-      readable-stream: 2.3.7
-      typedarray: 0.0.6
-    dev: false
-
   /connect-history-api-fallback/1.6.0:
     resolution: {integrity: sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==}
     engines: {node: '>=0.8'}
@@ -2757,15 +2731,6 @@ packages:
       tslib: 2.2.0
     dev: false
 
-  /duplexify/3.7.1:
-    resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
-    dependencies:
-      end-of-stream: 1.4.4
-      inherits: 2.0.4
-      readable-stream: 2.3.7
-      stream-shift: 1.0.1
-    dev: false
-
   /earcut/2.2.2:
     resolution: {integrity: sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==}
     dev: false
@@ -2983,19 +2948,6 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: false
-
-  /escodegen/1.14.3:
-    resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
-    engines: {node: '>=4.0'}
-    hasBin: true
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 4.3.0
-      esutils: 2.0.3
-      optionator: 0.8.3
-    optionalDependencies:
-      source-map: 0.6.1
     dev: false
 
   /escodegen/2.0.0:
@@ -3467,16 +3419,6 @@ packages:
       - supports-color
     dev: false
 
-  /falafel/2.2.4:
-    resolution: {integrity: sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==}
-    engines: {node: '>=0.4.0'}
-    dependencies:
-      acorn: 7.4.1
-      foreach: 2.0.5
-      isarray: 2.0.5
-      object-keys: 1.1.1
-    dev: false
-
   /fast-deep-equal/1.1.0:
     resolution: {integrity: sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=}
     dev: false
@@ -3677,10 +3619,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /foreach/2.0.5:
-    resolution: {integrity: sha1-C+4AUBiusmDQo6865ljdATbsG5k=}
-    dev: false
-
   /foreground-child/2.0.0:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
     engines: {node: '>=8.0.0'}
@@ -3713,13 +3651,6 @@ packages:
   /fresh/0.5.2:
     resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
     engines: {node: '>= 0.6'}
-    dev: false
-
-  /from2/2.3.0:
-    resolution: {integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=}
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.7
     dev: false
 
   /fromentries/1.3.2:
@@ -3912,119 +3843,6 @@ packages:
       ignore: 3.3.10
       pify: 3.0.0
       slash: 1.0.0
-    dev: false
-
-  /glsl-inject-defines/1.0.3:
-    resolution: {integrity: sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=}
-    dependencies:
-      glsl-token-inject-block: 1.1.0
-      glsl-token-string: 1.0.1
-      glsl-tokenizer: 2.1.5
-    dev: false
-
-  /glsl-resolve/0.0.1:
-    resolution: {integrity: sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=}
-    dependencies:
-      resolve: 0.6.3
-      xtend: 2.2.0
-    dev: false
-
-  /glsl-token-assignments/2.0.2:
-    resolution: {integrity: sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8=}
-    dev: false
-
-  /glsl-token-defines/1.0.0:
-    resolution: {integrity: sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=}
-    dependencies:
-      glsl-tokenizer: 2.1.5
-    dev: false
-
-  /glsl-token-depth/1.1.2:
-    resolution: {integrity: sha1-I8XjDuK9JViEtKKLyFC495HpXYQ=}
-    dev: false
-
-  /glsl-token-descope/1.0.2:
-    resolution: {integrity: sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=}
-    dependencies:
-      glsl-token-assignments: 2.0.2
-      glsl-token-depth: 1.1.2
-      glsl-token-properties: 1.0.1
-      glsl-token-scope: 1.1.2
-    dev: false
-
-  /glsl-token-inject-block/1.1.0:
-    resolution: {integrity: sha1-4QFfWYDBCRgkraomJfHf3ovQADQ=}
-    dev: false
-
-  /glsl-token-properties/1.0.1:
-    resolution: {integrity: sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4=}
-    dev: false
-
-  /glsl-token-scope/1.1.2:
-    resolution: {integrity: sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E=}
-    dev: false
-
-  /glsl-token-string/1.0.1:
-    resolution: {integrity: sha1-WUQdL4V958NEnJRWZgIezjWOSOw=}
-    dev: false
-
-  /glsl-token-whitespace-trim/1.0.0:
-    resolution: {integrity: sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA=}
-    dev: false
-
-  /glsl-tokenizer/2.1.5:
-    resolution: {integrity: sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==}
-    dependencies:
-      through2: 0.6.5
-    dev: false
-
-  /glslify-bundle/5.1.1:
-    resolution: {integrity: sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==}
-    dependencies:
-      glsl-inject-defines: 1.0.3
-      glsl-token-defines: 1.0.0
-      glsl-token-depth: 1.1.2
-      glsl-token-descope: 1.0.2
-      glsl-token-scope: 1.1.2
-      glsl-token-string: 1.0.1
-      glsl-token-whitespace-trim: 1.0.0
-      glsl-tokenizer: 2.1.5
-      murmurhash-js: 1.0.0
-      shallow-copy: 0.0.1
-    dev: false
-
-  /glslify-deps/1.3.2:
-    resolution: {integrity: sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==}
-    dependencies:
-      '@choojs/findup': 0.2.1
-      events: 3.3.0
-      glsl-resolve: 0.0.1
-      glsl-tokenizer: 2.1.5
-      graceful-fs: 4.2.6
-      inherits: 2.0.4
-      map-limit: 0.0.1
-      resolve: 1.20.0
-    dev: false
-
-  /glslify/7.1.1:
-    resolution: {integrity: sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==}
-    hasBin: true
-    dependencies:
-      bl: 2.2.1
-      concat-stream: 1.6.2
-      duplexify: 3.7.1
-      falafel: 2.2.4
-      from2: 2.3.0
-      glsl-resolve: 0.0.1
-      glsl-token-whitespace-trim: 1.0.0
-      glslify-bundle: 5.1.1
-      glslify-deps: 1.3.2
-      minimist: 1.2.5
-      resolve: 1.20.0
-      stack-trace: 0.0.9
-      static-eval: 2.1.0
-      through2: 2.0.5
-      xtend: 4.0.2
     dev: false
 
   /graceful-fs/4.2.6:
@@ -4699,10 +4517,6 @@ packages:
     resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
     dev: false
 
-  /isarray/2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
-    dev: false
-
   /isbinaryfile/4.0.8:
     resolution: {integrity: sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==}
     engines: {node: '>= 8.0.0'}
@@ -5320,12 +5134,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /map-limit/0.0.1:
-    resolution: {integrity: sha1-63lhAxwPDo0AG/LVb6toXViCLzg=}
-    dependencies:
-      once: 1.3.3
-    dev: false
-
   /map-visit/1.0.0:
     resolution: {integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=}
     engines: {node: '>=0.10.0'}
@@ -5514,10 +5322,6 @@ packages:
 
   /multimap/1.1.0:
     resolution: {integrity: sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==}
-    dev: false
-
-  /murmurhash-js/1.0.0:
-    resolution: {integrity: sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=}
     dev: false
 
   /nan/2.14.2:
@@ -5785,12 +5589,6 @@ packages:
   /on-headers/1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
     engines: {node: '>= 0.8'}
-    dev: false
-
-  /once/1.3.3:
-    resolution: {integrity: sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=}
-    dependencies:
-      wrappy: 1.0.2
     dev: false
 
   /once/1.4.0:
@@ -6611,10 +6409,6 @@ packages:
     deprecated: https://github.com/lydell/resolve-url#deprecated
     dev: false
 
-  /resolve/0.6.3:
-    resolution: {integrity: sha1-3ZV5gufnNt699TtYpN2RdUV13UY=}
-    dev: false
-
   /resolve/1.19.0:
     resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
     dependencies:
@@ -6847,10 +6641,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
-    dev: false
-
-  /shallow-copy/0.0.1:
-    resolution: {integrity: sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=}
     dev: false
 
   /shebang-command/1.2.0:
@@ -7128,16 +6918,6 @@ packages:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
     dev: false
 
-  /stack-trace/0.0.9:
-    resolution: {integrity: sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=}
-    dev: false
-
-  /static-eval/2.1.0:
-    resolution: {integrity: sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==}
-    dependencies:
-      escodegen: 1.14.3
-    dev: false
-
   /static-extend/0.1.2:
     resolution: {integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=}
     engines: {node: '>=0.10.0'}
@@ -7149,10 +6929,6 @@ packages:
   /statuses/1.5.0:
     resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
     engines: {node: '>= 0.6'}
-    dev: false
-
-  /stream-shift/1.0.1:
-    resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
     dev: false
 
   /streamroller/2.2.4:
@@ -7421,20 +7197,6 @@ packages:
       xtend: 4.0.2
     dev: false
 
-  /through2/0.6.5:
-    resolution: {integrity: sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=}
-    dependencies:
-      readable-stream: 1.0.34
-      xtend: 4.0.2
-    dev: false
-
-  /through2/2.0.5:
-    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
-    dependencies:
-      readable-stream: 2.3.7
-      xtend: 4.0.2
-    dev: false
-
   /thunky/1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
     dev: false
@@ -7638,10 +7400,6 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
-    dev: false
-
-  /typedarray/0.0.6:
-    resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
     dev: false
 
   /typescript/4.2.4:
@@ -8147,11 +7905,6 @@ packages:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: false
 
-  /xtend/2.2.0:
-    resolution: {integrity: sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=}
-    engines: {node: '>=0.4'}
-    dev: false
-
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -8268,7 +8021,7 @@ packages:
     dev: false
 
   file:projects/core.tgz:
-    resolution: {integrity: sha512-CfwMtpZzYZDNfQEf9lexaa2XYBDUflQ0btKFCizybl38LtcbPnChCF1OcIaBWqZgn+HA8jy5zJ7fXcF8qpm37g==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-OmiXCZ9NHmHWDvpzJsY7H2okTAwjGJ+9xo/3BhwIF9ibZsbQK1k34QhBvX4XCXmVd9/QPimTCw8J9Qq2bMBuIg==, tarball: file:projects/core.tgz}
     name: '@rush-temp/core'
     version: 0.0.0
     dependencies:
@@ -8290,7 +8043,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       inversify: 5.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       jsdom: 16.6.0
@@ -8336,7 +8088,7 @@ packages:
     dev: false
 
   file:projects/createjs.tgz:
-    resolution: {integrity: sha512-k70/06LnIAmeauaA6J24MevBjwf/lQPJppAKS0WaFAloQgOe7b43bBaoI0Fo+B1De/nQoPV/XinzCwO6hLfdLA==, tarball: file:projects/createjs.tgz}
+    resolution: {integrity: sha512-n+PUh1YOKYistJ7gaGyKXajhlLjDx082GXUzolF+IGfPIfJSlKTfVFTDZubPprCE1lpBZsVvQG6be9Ym+dLEJA==, tarball: file:projects/createjs.tgz}
     name: '@rush-temp/createjs'
     version: 0.0.0
     dependencies:
@@ -8364,7 +8116,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -8406,7 +8157,7 @@ packages:
     dev: false
 
   file:projects/eventemitter3.tgz:
-    resolution: {integrity: sha512-xtV+T4HDT0yr0kpUWloeVBtEHIfbiiA1+HU10P7vLRt8WP4BXWiil/IgM74taFMdYrEig809cefXzyMset4PfA==, tarball: file:projects/eventemitter3.tgz}
+    resolution: {integrity: sha512-OjItDQCOsTGsKw3Hk2ta/i/0faq/c/IXfcKkj/+1VyJhZ81vZUS/freOYbaTNCKfDSqWsJdbMA0CItoMTWi42A==, tarball: file:projects/eventemitter3.tgz}
     name: '@rush-temp/eventemitter3'
     version: 0.0.0
     dependencies:
@@ -8429,7 +8180,6 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
       eventemitter3: 4.0.7
-      glslify: 7.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       jsdom: 16.6.0
       jsdom-global: 3.0.2_jsdom@16.6.0
@@ -8773,7 +8523,7 @@ packages:
     dev: false
 
   file:projects/integration-macrobot-signalcommandmap.tgz:
-    resolution: {integrity: sha512-UQcqEolN3zln35cNLz62BgJv5Oa6JPmeiVvy/QCmBSpexyd/rELmN7kV5f6eA5cOKmL8crXH5NqB/TK8UKKsvw==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
+    resolution: {integrity: sha512-L0qCEVu3MXNQ+joMqhgFSULBWqA4sCoATaeJVtoMXHa9+DCNA2Z/1cbq7PGV9OmvathPXhuAPl6yIkXdFEv1+A==, tarball: file:projects/integration-macrobot-signalcommandmap.tgz}
     name: '@rush-temp/integration-macrobot-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8795,7 +8545,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8837,7 +8586,7 @@ packages:
     dev: false
 
   file:projects/macrobot.tgz:
-    resolution: {integrity: sha512-xpMmmA20HADUX/WebBd8F/zFi2GrGqxmGkjck+EUB6jkiFN5ADNIdzgQqXhVB3Cv9G5bp1fknOGO4Q/TT9fEzw==, tarball: file:projects/macrobot.tgz}
+    resolution: {integrity: sha512-VsRb2q5fLK32A5kMAwk+uyjOJfuh/gpUGto8Rep4cjX+jYGJr/LKYb9yDcSNWwf912Fzn2ePuJsBHJ9pQvPcJQ==, tarball: file:projects/macrobot.tgz}
     name: '@rush-temp/macrobot'
     version: 0.0.0
     dependencies:
@@ -8859,7 +8608,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -8901,7 +8649,7 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-dkQ/uXMLf4N5zsg7H3TRL5kkIobVNC0s8BrxX30dH3OI6ICadQj6quU1E7Q/hqUrGHKDTZuEpVCkwsf1MxJCsw==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-6l2JjGKZMvZ0ETVPWUq9EMY0zEEKZuXtJgxKuRuipVZJHK8u4qwb7KbKBZMsY5Ajy/gjb7NusIZcpGmwj4R+jw==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
@@ -8925,7 +8673,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -8967,7 +8714,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce-signalcommandmap.tgz:
-    resolution: {integrity: sha512-uDvmCj0vp+byG/Yx8oZFnMLgobEx7Ah3n1t/RSsCNktuaCW1j5fcJL5R9QpIttpig6mmzembrWMfEPCldJXGdg==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
+    resolution: {integrity: sha512-KwriZYzsomAvVGQisun0peft0wH3+b8KsRUIi9+ii9z/ktItJXefWP91Dcd9tj2UuXaJN63UZiErsBqBsP087w==, tarball: file:projects/phaser-ce-signalcommandmap.tgz}
     name: '@rush-temp/phaser-ce-signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -8988,7 +8735,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9029,7 +8775,7 @@ packages:
     dev: false
 
   file:projects/phaser-ce.tgz:
-    resolution: {integrity: sha512-8ipCn7Xx0N6BV1feFRDfJnLCAsgQYAODXlt4Y4/hmRq+X2mO/ThOnrJhEZXm/ax1nrexWXEBsaomuiaZwMB9HA==, tarball: file:projects/phaser-ce.tgz}
+    resolution: {integrity: sha512-BgAIFaNP/I21ugrJMuRI4eSRF/QyCAjGgnfdXNLlkLeuIFRMWCmG4RR4PWC+JQX3HMtmikCQbkUhDUwNTBRy7w==, tarball: file:projects/phaser-ce.tgz}
     name: '@rush-temp/phaser-ce'
     version: 0.0.0
     dependencies:
@@ -9052,7 +8798,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9095,7 +8840,7 @@ packages:
     dev: false
 
   file:projects/phaser.tgz:
-    resolution: {integrity: sha512-dud4MniLyyJmGmY8L8FfP6bVnPh8o4BqvW0jssc7rviwQbZCOTBPVKyCacbdN/GEss9LL9UZVNQGLUyYNtOv7A==, tarball: file:projects/phaser.tgz}
+    resolution: {integrity: sha512-ibpIw8ZmPcuoWOZJH9e+ee+GM1FWNlMgetR+Y1q9oPRN3HJwrTNl0zK4TZag6ykCBaQP5iUZGMhjNLjozVaxEA==, tarball: file:projects/phaser.tgz}
     name: '@rush-temp/phaser'
     version: 0.0.0
     dependencies:
@@ -9119,7 +8864,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9162,7 +8906,7 @@ packages:
     dev: false
 
   file:projects/pixi-palidor.tgz:
-    resolution: {integrity: sha512-qo05l4DQtdn7MgHnMWI2tYBvdCTjrRGLVBrEPuLAhmKBbvHEm8DEfiSY833tk7bW1jYfsihnAchDVOJb9LnoGw==, tarball: file:projects/pixi-palidor.tgz}
+    resolution: {integrity: sha512-e3d2/tsFqxxjN8alPB0yTDis+sU4ru79FNrf44gowKgWHUmjK6eSlKorJ5FtI9UuQmf4EI/9/5khY1vnlAFYNA==, tarball: file:projects/pixi-palidor.tgz}
     name: '@rush-temp/pixi-palidor'
     version: 0.0.0
     dependencies:
@@ -9185,7 +8929,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9227,7 +8970,7 @@ packages:
     dev: false
 
   file:projects/pixi-signalmediator.tgz:
-    resolution: {integrity: sha512-zf0+uduQ1P19cbx2D19iDKphepgSapbWHyx9xOHeqv3x5KfFtPnz0p4OjahSVgVSKEFHdEgaqV+iYioTrIe0nw==, tarball: file:projects/pixi-signalmediator.tgz}
+    resolution: {integrity: sha512-5ErglEmmpeTLv3RJhZaOsD8Md9g7m8AS4oifMUpm1nzBhvqZyD3T5VsTkZ7PGmEOtpD+QQOqpQXsRf7MPXaCCA==, tarball: file:projects/pixi-signalmediator.tgz}
     name: '@rush-temp/pixi-signalmediator'
     version: 0.0.0
     dependencies:
@@ -9249,7 +8992,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9292,7 +9034,7 @@ packages:
     dev: false
 
   file:projects/pixi.tgz:
-    resolution: {integrity: sha512-ZySfPMcR/41oDsSQ3ajV26JHkFb03sEcp76uLGPxYa8+rjPaLN4I8LkQeSo+4k8D5vWz5MPVc1oPzMq5gneZeQ==, tarball: file:projects/pixi.tgz}
+    resolution: {integrity: sha512-FpN9KV4CRH8f63GK+Fqo3atIBy23WX56co39fKCP03HfzkYZX/IwHCnPmJOGvaTBec7GtKZ0KMJRXhhd4Ab/sQ==, tarball: file:projects/pixi.tgz}
     name: '@rush-temp/pixi'
     version: 0.0.0
     dependencies:
@@ -9315,7 +9057,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       html-webpack-plugin: 5.3.2_webpack@5.40.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
@@ -9357,7 +9098,7 @@ packages:
     dev: false
 
   file:projects/signalcommandmap.tgz:
-    resolution: {integrity: sha512-k91KvYc9Vnu+dQgbqJk4W7j7k3CTqwGNwcw732/T19HyGeUCEsF9d2k/kXc7qRGM1iDuxeaYkFUI6ocMTtWMyw==, tarball: file:projects/signalcommandmap.tgz}
+    resolution: {integrity: sha512-+I0bXpY6wSHorJW3W+4MMQFasEMeNWFBmDeELzUsUXEnADjDE/tedNSBNen2u0ZznL12oZL6Z17KCjozppkuLw==, tarball: file:projects/signalcommandmap.tgz}
     name: '@rush-temp/signalcommandmap'
     version: 0.0.0
     dependencies:
@@ -9379,7 +9120,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0
@@ -9421,7 +9161,7 @@ packages:
     dev: false
 
   file:projects/signals.tgz:
-    resolution: {integrity: sha512-/LIqmtFsJ+vCfexryi1iu4HIP28BBKluqQkjdzatz7440XTOwHaP4rUn0ifLm+HdAC4tJJrImfIOnirr51YqNA==, tarball: file:projects/signals.tgz}
+    resolution: {integrity: sha512-FhiVDtFlBZngHQFZdHR2HczcKqcFqccQUS/qblkBIhtb0ZpGOSl9j02AEIMd09i92K0N5dcZLAN1mUuw19xEvA==, tarball: file:projects/signals.tgz}
     name: '@rush-temp/signals'
     version: 0.0.0
     dependencies:
@@ -9443,7 +9183,6 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.29.0
       eslint-plugin-react: 7.24.0_eslint@7.29.0
       eslint-plugin-unicorn: 33.0.1_eslint@7.29.0
-      glslify: 7.1.1
       istanbul-instrumenter-loader: 3.0.1_webpack@5.40.0
       karma: 6.3.4
       karma-chrome-launcher: 3.1.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -26,7 +26,6 @@ specifiers:
   '@rushstack/eslint-config': ^2.3.4
   '@types/bluebird': ^3.5.35
   '@types/chai': ^4.2.19
-  '@types/core-js': ^2.5.4
   '@types/createjs-lib': ^0.0.29
   '@types/easeljs': ^1.0.0
   '@types/mocha': ^8.2.2
@@ -108,7 +107,6 @@ dependencies:
   '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
   '@types/bluebird': 3.5.35
   '@types/chai': 4.2.19
-  '@types/core-js': 2.5.4
   '@types/createjs-lib': 0.0.29
   '@types/easeljs': 1.0.0
   '@types/mocha': 8.2.2
@@ -929,10 +927,6 @@ packages:
 
   /@types/cookie/0.4.0:
     resolution: {integrity: sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==}
-    dev: false
-
-  /@types/core-js/2.5.4:
-    resolution: {integrity: sha512-Xwy8o12ak+iYgFr/KCVaVK5Sy+jFMiiPAID3+ObvMlBzy26XQJw5xu+a6rlHsrJENXj/AwJOGsJpVohUjAzSKQ==}
     dev: false
 
   /@types/cors/2.8.10:
@@ -8606,14 +8600,13 @@ packages:
     dev: false
 
   file:projects/openfl.tgz:
-    resolution: {integrity: sha512-XR/NPZo14aaR75pWmN7Uby+gDA0MVlyYjk0asuQVNtVnrUGsBQLqKgSlqp9zX0nw3+5APW6cUrCQgnetDbdUNw==, tarball: file:projects/openfl.tgz}
+    resolution: {integrity: sha512-QPAViFWaGzjfzAOXPzKIcT85X7LKA60iIxWqs06SKopcffAT4PnldSe4jqySBEhjttnKjoOtkM0qYKfzVR3Kfw==, tarball: file:projects/openfl.tgz}
     name: '@rush-temp/openfl'
     version: 0.0.0
     dependencies:
       '@rushstack/eslint-config': 2.3.4_eslint@7.29.0+typescript@4.2.4
       '@types/bluebird': 3.5.35
       '@types/chai': 4.2.19
-      '@types/core-js': 2.5.4
       '@types/mocha': 8.2.2
       '@types/sinon': 10.0.2
       '@types/webpack-env': 1.16.0

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "55b9c3238b7787bd94d7469138f21a7cb1347bc1"
+  "pnpmShrinkwrapHash": "f60cbfc5f98065d47418403fb57cf2aba6b8fbb8"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "7be8ba7fcace288cb8a37078c9ef5badd539d95f"
+  "pnpmShrinkwrapHash": "837e13668e791ca211426bdd0a2f56e8341fa0c0"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9c48d7cbd8c2c6cae5888aaa6dc3a817edb45a44"
+  "pnpmShrinkwrapHash": "2ae0fc5c63b27c141098f96cc9c6a6006f3313d2"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "c16dc36786bf4398c47bfa04640beffb4955b4a5"
+  "pnpmShrinkwrapHash": "90b0dfd079cb8206b6f8780c3dcd4448c22ff1d8"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "2ae0fc5c63b27c141098f96cc9c6a6006f3313d2"
+  "pnpmShrinkwrapHash": "93a1325f1f7febe54d70427a87dfc37dc9d5bed8"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "93a1325f1f7febe54d70427a87dfc37dc9d5bed8"
+  "pnpmShrinkwrapHash": "d50daf394a566eb890e5d8dc6a4e45d671cef753"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "ce85959530ed2792345ecbf9485a08f7ae418b62"
+  "pnpmShrinkwrapHash": "55b9c3238b7787bd94d7469138f21a7cb1347bc1"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "e00981fe8774f03f0980bb4f20b9a62ce572eb71"
+  "pnpmShrinkwrapHash": "9c48d7cbd8c2c6cae5888aaa6dc3a817edb45a44"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "287eb7ba8f20f7be37b97bb3a83e36d8ed213ad2"
+  "pnpmShrinkwrapHash": "c16dc36786bf4398c47bfa04640beffb4955b4a5"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "837e13668e791ca211426bdd0a2f56e8341fa0c0"
+  "pnpmShrinkwrapHash": "e00981fe8774f03f0980bb4f20b9a62ce572eb71"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "d50daf394a566eb890e5d8dc6a4e45d671cef753"
+  "pnpmShrinkwrapHash": "287eb7ba8f20f7be37b97bb3a83e36d8ed213ad2"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "c72b2fc29f0378839707abb5ba18abc1e19fb78f"
+  "pnpmShrinkwrapHash": "7be8ba7fcace288cb8a37078c9ef5badd539d95f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f60cbfc5f98065d47418403fb57cf2aba6b8fbb8"
+  "pnpmShrinkwrapHash": "c72b2fc29f0378839707abb5ba18abc1e19fb78f"
 }

--- a/games/battleship/karma.conf.js
+++ b/games/battleship/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -41,7 +41,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/games/battleship/karma.conf.js
+++ b/games/battleship/karma.conf.js
@@ -51,7 +51,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/games/battleship/package.json
+++ b/games/battleship/package.json
@@ -76,7 +76,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/games/battleship/package.json
+++ b/games/battleship/package.json
@@ -51,7 +51,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/games/battleship/package.json
+++ b/games/battleship/package.json
@@ -72,6 +72,7 @@
     "puppeteer": "^10.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
+    "sinon-chai": "^3.7.0",
     "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",

--- a/games/battleship/package.json
+++ b/games/battleship/package.json
@@ -72,7 +72,7 @@
     "puppeteer": "^10.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/games/battleship/package.json
+++ b/games/battleship/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/games/battleship/package.json
+++ b/games/battleship/package.json
@@ -60,7 +60,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/games/match3/karma.conf.js
+++ b/games/match3/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -41,7 +41,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/games/match3/karma.conf.js
+++ b/games/match3/karma.conf.js
@@ -51,7 +51,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/games/match3/package.json
+++ b/games/match3/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/games/match3/package.json
+++ b/games/match3/package.json
@@ -67,6 +67,7 @@
     "puppeteer": "^10.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
+    "sinon-chai": "^3.7.0",
     "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",

--- a/games/match3/package.json
+++ b/games/match3/package.json
@@ -46,7 +46,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/games/match3/package.json
+++ b/games/match3/package.json
@@ -67,7 +67,7 @@
     "puppeteer": "^10.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/games/match3/package.json
+++ b/games/match3/package.json
@@ -71,7 +71,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/games/match3/package.json
+++ b/games/match3/package.json
@@ -55,7 +55,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/games/minesweeper/karma.conf.js
+++ b/games/minesweeper/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -41,7 +41,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/games/minesweeper/karma.conf.js
+++ b/games/minesweeper/karma.conf.js
@@ -51,7 +51,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/games/minesweeper/package.json
+++ b/games/minesweeper/package.json
@@ -76,7 +76,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/games/minesweeper/package.json
+++ b/games/minesweeper/package.json
@@ -51,7 +51,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/games/minesweeper/package.json
+++ b/games/minesweeper/package.json
@@ -72,6 +72,7 @@
     "puppeteer": "^10.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
+    "sinon-chai": "^3.7.0",
     "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",

--- a/games/minesweeper/package.json
+++ b/games/minesweeper/package.json
@@ -72,7 +72,7 @@
     "puppeteer": "^10.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/games/minesweeper/package.json
+++ b/games/minesweeper/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/games/minesweeper/package.json
+++ b/games/minesweeper/package.json
@@ -60,7 +60,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/games/scratchcard/package.json
+++ b/games/scratchcard/package.json
@@ -29,7 +29,7 @@
     "@rushstack/eslint-config": "^2.3.4",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/games/scratchcard/package.json
+++ b/games/scratchcard/package.json
@@ -41,7 +41,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/games/scratchcard/package.json
+++ b/games/scratchcard/package.json
@@ -37,7 +37,7 @@
     "imports-loader": "^3.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/games/scratchcard/package.json
+++ b/games/scratchcard/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/games/scratchcard/package.json
+++ b/games/scratchcard/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
     "terser-webpack-plugin": "^5.1.4",

--- a/games/space-invaders/package.json
+++ b/games/space-invaders/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
     "terser-webpack-plugin": "^5.1.4",

--- a/games/space-invaders/package.json
+++ b/games/space-invaders/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/games/space-invaders/package.json
+++ b/games/space-invaders/package.json
@@ -49,7 +49,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/games/space-invaders/package.json
+++ b/games/space-invaders/package.json
@@ -37,7 +37,7 @@
     "@rushstack/eslint-config": "^2.3.4",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/games/space-invaders/package.json
+++ b/games/space-invaders/package.json
@@ -45,7 +45,7 @@
     "imports-loader": "^3.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/games/tetris/package.json
+++ b/games/tetris/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "mocha": "^9.0.1",
     "nyc": "^15.1.0",
     "prettier": "^2.3.1",

--- a/games/tetris/package.json
+++ b/games/tetris/package.json
@@ -78,7 +78,7 @@
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/games/tetris/package.json
+++ b/games/tetris/package.json
@@ -68,7 +68,7 @@
     "chai": "^4.3.4",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/games/tetris/package.json
+++ b/games/tetris/package.json
@@ -82,7 +82,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/integration-tests/macrobot-signalcommandmap/karma.conf.js
+++ b/integration-tests/macrobot-signalcommandmap/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
 
   var configuration = {
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -36,7 +36,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/integration-tests/macrobot-signalcommandmap/karma.conf.js
+++ b/integration-tests/macrobot-signalcommandmap/karma.conf.js
@@ -46,7 +46,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -84,7 +84,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -80,7 +80,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -107,7 +107,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -85,7 +85,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -111,7 +111,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -74,7 +74,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -88,7 +88,6 @@
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
-    "karma-chai-sinon": "^0.1.5",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-es6-shim": "^1.0.0",

--- a/integration-tests/macrobot-signalcommandmap/package.json
+++ b/integration-tests/macrobot-signalcommandmap/package.json
@@ -90,7 +90,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
 
   var configuration = {
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -36,7 +36,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -46,7 +46,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,7 +98,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jsdom": "^16.6.0",
     "jsdom-global": "^3.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,7 +104,6 @@
     "jsdom-global": "^3.0.2",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
-    "karma-commonjs": "^1.0.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -126,7 +126,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -122,7 +122,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,7 +87,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,7 +93,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jsdom": "^16.6.0",
     "jsdom-global": "^3.0.2",

--- a/packages/createjs/karma.conf.js
+++ b/packages/createjs/karma.conf.js
@@ -52,7 +52,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/createjs/karma.conf.js
+++ b/packages/createjs/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -42,7 +42,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -106,7 +106,6 @@
     "prettier": "^2.3.1",
     "puppeteer": "^10.0.0",
     "reflect-metadata": "^0.1.13",
-    "remap-istanbul": "^0.13.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -85,7 +85,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -111,7 +111,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -115,7 +115,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.example.config.js",
     "test": "node --max-old-space-size=2048 ./node_modules/karma/bin/karma start --single-run",
-    "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -79,7 +79,7 @@
     "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
-    "copy-webpack-plugin": "^9.0.0",
+    "copy-webpack-plugin": "^9.0.1",
     "easeljs": "^1.0.2",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -91,7 +91,6 @@
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -76,7 +76,6 @@
     "@types/tweenjs": "^1.0.3",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^9.0.1",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -96,7 +96,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/createjs/package.json
+++ b/packages/createjs/package.json
@@ -89,7 +89,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/eventemitter3/karma.conf.js
+++ b/packages/eventemitter3/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
 
   var configuration = {
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -36,7 +36,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/eventemitter3/karma.conf.js
+++ b/packages/eventemitter3/karma.conf.js
@@ -46,7 +46,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/eventemitter3/package.json
+++ b/packages/eventemitter3/package.json
@@ -101,7 +101,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "eventemitter3": "^4.0.0",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jsdom": "^16.6.0",
     "jsdom-global": "^3.0.2",

--- a/packages/eventemitter3/package.json
+++ b/packages/eventemitter3/package.json
@@ -125,7 +125,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/eventemitter3/package.json
+++ b/packages/eventemitter3/package.json
@@ -129,7 +129,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/eventemitter3/package.json
+++ b/packages/eventemitter3/package.json
@@ -90,7 +90,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/eventemitter3/package.json
+++ b/packages/eventemitter3/package.json
@@ -109,7 +109,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/eventemitter3/package.json
+++ b/packages/eventemitter3/package.json
@@ -102,7 +102,6 @@
     "eslint-plugin-unicorn": "^33.0.1",
     "eventemitter3": "^4.0.0",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jsdom": "^16.6.0",
     "jsdom-global": "^3.0.2",

--- a/packages/eventemitter3/package.json
+++ b/packages/eventemitter3/package.json
@@ -96,7 +96,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/macrobot/karma.conf.js
+++ b/packages/macrobot/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
 
   var configuration = {
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -36,7 +36,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/macrobot/karma.conf.js
+++ b/packages/macrobot/karma.conf.js
@@ -46,7 +46,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -107,7 +107,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -128,7 +128,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -91,7 +91,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -105,7 +105,6 @@
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
-    "karma-chai-sinon": "^0.1.5",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-es6-shim": "^1.0.0",

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -102,7 +102,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -97,7 +97,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -101,7 +101,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/macrobot/package.json
+++ b/packages/macrobot/package.json
@@ -124,7 +124,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/openfl/karma.conf.js
+++ b/packages/openfl/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -41,7 +41,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/openfl/karma.conf.js
+++ b/packages/openfl/karma.conf.js
@@ -51,7 +51,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -92,7 +92,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.example.config.js",
     "test": "node --max-old-space-size=2048 ./node_modules/karma/bin/karma start --single-run",
-    "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -76,7 +76,7 @@
     "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
-    "copy-webpack-plugin": "^9.0.0",
+    "copy-webpack-plugin": "^9.0.1",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -111,7 +111,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -85,7 +85,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -87,7 +87,6 @@
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -68,7 +68,6 @@
     "@rushstack/eslint-config": "^2.3.4",
     "@types/bluebird": "^3.5.35",
     "@types/chai": "^4.2.19",
-    "@types/core-js": "^2.5.4",
     "@types/mocha": "^8.2.2",
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -107,7 +107,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -73,7 +73,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^9.0.1",

--- a/packages/openfl/package.json
+++ b/packages/openfl/package.json
@@ -81,7 +81,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/phaser-ce-signalcommandmap/karma.conf.js
+++ b/packages/phaser-ce-signalcommandmap/karma.conf.js
@@ -52,7 +52,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/phaser-ce-signalcommandmap/karma.conf.js
+++ b/packages/phaser-ce-signalcommandmap/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -42,7 +42,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -99,7 +99,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -79,7 +79,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -74,7 +74,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -84,7 +84,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -68,7 +68,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -6,7 +6,6 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "test": "karma start --single-run",
-    "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -78,7 +78,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/phaser-ce-signalcommandmap/package.json
+++ b/packages/phaser-ce-signalcommandmap/package.json
@@ -103,7 +103,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/phaser-ce/karma.conf.js
+++ b/packages/phaser-ce/karma.conf.js
@@ -52,7 +52,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/phaser-ce/karma.conf.js
+++ b/packages/phaser-ce/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -42,7 +42,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -79,7 +79,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -85,7 +85,6 @@
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.example.config.js",
     "test": "karma start --single-run",
-    "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -109,7 +109,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -105,7 +105,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -83,7 +83,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -90,7 +90,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/phaser-ce/package.json
+++ b/packages/phaser-ce/package.json
@@ -72,7 +72,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
     "es6-map": "^0.1.5",

--- a/packages/phaser/karma.conf.js
+++ b/packages/phaser/karma.conf.js
@@ -52,7 +52,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/phaser/karma.conf.js
+++ b/packages/phaser/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -42,7 +42,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -85,7 +85,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -111,7 +111,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -115,7 +115,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -80,7 +80,7 @@
     "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
-    "copy-webpack-plugin": "^9.0.0",
+    "copy-webpack-plugin": "^9.0.1",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -77,7 +77,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^9.0.1",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.example.config.js",
     "test": "karma start --single-run",
-    "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -91,7 +91,6 @@
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -96,7 +96,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/phaser/package.json
+++ b/packages/phaser/package.json
@@ -89,7 +89,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/pixi-palidor/karma.conf.js
+++ b/packages/pixi-palidor/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -41,7 +41,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/pixi-palidor/karma.conf.js
+++ b/packages/pixi-palidor/karma.conf.js
@@ -51,7 +51,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -75,7 +75,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^9.0.1",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -110,7 +110,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -78,7 +78,7 @@
     "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
-    "copy-webpack-plugin": "^9.0.0",
+    "copy-webpack-plugin": "^9.0.1",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -83,7 +83,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -114,7 +114,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -89,7 +89,6 @@
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -94,7 +94,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -105,7 +105,6 @@
     "prettier": "^2.3.1",
     "puppeteer": "^10.0.0",
     "reflect-metadata": "^0.1.13",
-    "remap-istanbul": "^0.13.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -87,7 +87,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/pixi-palidor/package.json
+++ b/packages/pixi-palidor/package.json
@@ -8,7 +8,6 @@
     "start": "webpack serve --config ./webpack.example.config.js",
     "test": "./node_modules/.bin/karma start --single-run",
     "test:tdd": "./node_modules/.bin/karma start",
-    "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",

--- a/packages/pixi-signalmediator/.mocharc.json
+++ b/packages/pixi-signalmediator/.mocharc.json
@@ -1,7 +1,0 @@
-{
-  "recursive": true,
-  "full-trace": true,
-  "bail": true,
-  "spec": "./test/**/*.test.ts",
-  "require": "reflect-metadata"
-}

--- a/packages/pixi-signalmediator/karma.conf.js
+++ b/packages/pixi-signalmediator/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -41,7 +41,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/pixi-signalmediator/karma.conf.js
+++ b/packages/pixi-signalmediator/karma.conf.js
@@ -51,7 +51,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -6,7 +6,6 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "test": "karma start --single-run",
-    "mocha": "nyc mocha",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",
@@ -22,29 +21,6 @@
     "build": "npm run cleanup && npm run compile:src",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
-  },
-  "nyc": {
-    "extends": "@istanbuljs/nyc-config-typescript",
-    "include": [
-      "src/**/*.ts"
-    ],
-    "exclude": [
-      "test"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register",
-      "source-map-support/register"
-    ],
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ],
-    "check-coverage": true,
-    "sourceMap": true,
-    "instrument": true
   },
   "repository": {
     "url": "https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi-signalmediator"
@@ -86,7 +62,6 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@rushstack/eslint-config": "^2.3.4",
     "@types/bluebird": "^3.5.35",
     "@types/chai": "^4.2.19",
@@ -114,7 +89,6 @@
     "karma-sourcemap-writer": "^0.1.2",
     "karma-webpack": "^5.0.0",
     "mocha": "^9.0.1",
-    "nyc": "^15.1.0",
     "pixi.js": "^5.2.1",
     "prettier": "^2.3.1",
     "puppeteer": "^10.0.0",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -104,7 +104,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -105,7 +105,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -109,7 +109,6 @@
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
-    "karma-coverage": "^2.0.3",
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -94,7 +94,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -129,7 +129,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -122,7 +122,6 @@
     "prettier": "^2.3.1",
     "puppeteer": "^10.0.0",
     "reflect-metadata": "^0.1.13",
-    "remap-istanbul": "^0.13.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -133,7 +133,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -100,7 +100,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/pixi-signalmediator/package.json
+++ b/packages/pixi-signalmediator/package.json
@@ -110,7 +110,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/pixi/karma.conf.js
+++ b/packages/pixi/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
       }
     },
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -41,7 +41,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/pixi/karma.conf.js
+++ b/packages/pixi/karma.conf.js
@@ -51,7 +51,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -79,7 +79,7 @@
     "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
-    "copy-webpack-plugin": "^9.0.0",
+    "copy-webpack-plugin": "^9.0.1",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -76,7 +76,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^9.0.1",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.example.config.js",
     "test": "node --max-old-space-size=2048 ./node_modules/karma/bin/karma start --single-run",
-    "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write --list-different .",
     "lint-fix:src": "eslint -c .eslintrc.js --ext .ts ./src --fix",
     "lint-fix:test": "eslint -c .eslintrc.js --ext .ts ./test --fix",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.3.2",
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -90,7 +90,6 @@
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -110,7 +110,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -114,7 +114,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -95,7 +95,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -88,7 +88,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "html-webpack-plugin": "^5.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",

--- a/packages/pixi/package.json
+++ b/packages/pixi/package.json
@@ -84,7 +84,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/signalcommandmap/karma.conf.js
+++ b/packages/signalcommandmap/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
 
   var configuration = {
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -36,7 +36,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/signalcommandmap/karma.conf.js
+++ b/packages/signalcommandmap/karma.conf.js
@@ -46,7 +46,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/signalcommandmap/package.json
+++ b/packages/signalcommandmap/package.json
@@ -123,7 +123,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/signalcommandmap/package.json
+++ b/packages/signalcommandmap/package.json
@@ -98,7 +98,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/signalcommandmap/package.json
+++ b/packages/signalcommandmap/package.json
@@ -87,7 +87,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/signalcommandmap/package.json
+++ b/packages/signalcommandmap/package.json
@@ -93,7 +93,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/signalcommandmap/package.json
+++ b/packages/signalcommandmap/package.json
@@ -119,7 +119,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/signalcommandmap/package.json
+++ b/packages/signalcommandmap/package.json
@@ -97,7 +97,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/signalcommandmap/package.json
+++ b/packages/signalcommandmap/package.json
@@ -103,7 +103,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/signals/karma.conf.js
+++ b/packages/signals/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
 
   var configuration = {
     basePath: "",
-    frameworks: ["webpack", "mocha", "sinon-chai", "es6-shim"],
+    frameworks: ["webpack", "mocha", "sinon-chai"],
     files: [
       { pattern: "node_modules/reflect-metadata/Reflect.js", include: true },
       { pattern: "node_modules/bluebird/js/browser/bluebird.js", include: true },
@@ -36,7 +36,6 @@ module.exports = (config) => {
       "karma-mocha-reporter",
       "karma-mocha",
       "karma-sinon-chai",
-      "karma-es6-shim",
       "karma-coverage-istanbul-reporter"
     ],
     mime: {

--- a/packages/signals/karma.conf.js
+++ b/packages/signals/karma.conf.js
@@ -46,7 +46,9 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       "reports": ["html", "lcov", "lcovonly", "text-summary"],
       "dir": "coverage",
+      "combineBrowserReports": true,
       "fixWebpackSourcePaths": true,
+      "skipFilesWithNoCoverage": true,
       "report-config": {
         html: {
           subdir: "html-report"

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -95,7 +95,6 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
     "glslify": "^7.1.1",
-    "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -100,7 +100,6 @@
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
-    "karma-es6-shim": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon-chai": "^2.0.2",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -121,7 +121,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",
-    "webpack": "^5.39.1",
+    "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -84,7 +84,6 @@
     "@types/sinon": "^10.0.2",
     "@types/webpack-env": "^1.16.0",
     "bluebird": "^3.7.2",
-    "browserify-versionify": "^1.0.6",
     "chai": "^4.3.4",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.3",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -94,7 +94,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",
-    "glslify": "^7.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -117,7 +117,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
-    "terser-webpack-plugin": "^5.1.3",
+    "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "typescript": "~4.2.4",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -90,7 +90,7 @@
     "es6-symbol": "^3.1.3",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.3.2",
+    "eslint-plugin-jsdoc": "^35.4.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^33.0.1",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -98,7 +98,6 @@
     "imports-loader": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.4",
-    "karma-chai-sinon": "^0.1.5",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-es6-shim": "^1.0.0",


### PR DESCRIPTION
Use the same karma configuration properties on all projects using it:
- Use [karma-sinon-chai](https://www.npmjs.com/package/karma-sinon-chai) instead of [karma-chai-sinon](https://www.npmjs.com/package/karma-chai-sinon).
- Enable **combineBrowserReports** and **skipFilesWithNoCoverage** coverage reporter flags for istanbul.
- Remove [es6-shim](https://www.npmjs.com/package/es6-shim).

Remove outdated **mocha** script from packages that are running tests using **karma**.

Update dev dependency packages with newer version:
- Update [copy-webpack-plugin](https://www.npmjs.com/package/copy-webpack-plugin) to version **9.0.1**.
- Update [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc) to version **35.4.0**.
- Update [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) to version **5.3.2**.
- Update [terser-webpack-plugin](https://www.npmjs.com/package/terser-webpack-plugin) to version **5.1.4**.
- Update [webpack](https://www.npmjs.com/package/webpack) to version **5.40.0**.

Remove unused or outdated dev dependency packages:
- Remove [@types/core-js](https://www.npmjs.com/package/@types/core-js) dev dependency.
- Remove [browserify-versionify](https://www.npmjs.com/package/browserify-versionify) dev dependency.
- Remove [glslify](https://www.npmjs.com/package/glslify) dev dependency.
- Remove [imports-loader](https://www.npmjs.com/package/imports-loader) dev dependency.
- Remove [karma-chai-sinon](https://www.npmjs.com/package/karma-chai-sinon) dev dependency.
- Remove [karma-commonjs](https://www.npmjs.com/package/karma-commonjs) dev dependency.
- Remove [karma-coverage](https://www.npmjs.com/package/karma-coverage) dev dependency.
- Remove [karma-es6-shim](https://www.npmjs.com/package/karma-es6-shim) dev dependency.
- Remove [remap-istanbul](https://www.npmjs.com/package/remap-istanbul) dev dependency.
